### PR TITLE
Create some basic database utilities

### DIFF
--- a/macrostrat-cli/README.md
+++ b/macrostrat-cli/README.md
@@ -1,9 +1,13 @@
-# Macrostrat CLI
+# Macrostrat command-line interface
 
-This module, formerly known as _utils_, contains the central
-command-line application for orchestrating and managing the Macrostrat
-system. It includes scripts for service inspection, data maintenance,
-and other management utilities.
+The Macrostrat command-line interface is a tool for orchestrating and managing
+the Macrostrat platform, including its database(s) and services. It is designed
+both to bootstrap and control an standalone Macrostrat installation, and to help
+control the infrastructure of the entire Macrostrat project, which contains
+multiple databases for developement and differently-targeted collaborations.
+
+This module, formerly known as _utils_, contains the central command-line
+application for orchestrating and managing the Macrostrat system.
 
 ## Installation
 
@@ -12,8 +16,52 @@ and other management utilities.
 - `make install` (links the application into `/usr/local/bin`)
 - Optionally, install subsystems for additional functionality (coming soon)
 
-## Legacy code
+## Configuration
 
-The `utils` module that forms the core of this codebase was devised to manage
-the Macrostrat v1 system on a single server. This code is still available
-on the `v1` branch of this repository. 
+The CLI is configured using [Dynaconf](https://www.dynaconf.com/), which allows
+for a variety of configuration sources, including environment variables, YAML
+files, and TOML files. The most flexible way to configure the CLI is using a
+TOML file; an example is provide in
+[`macrostrat-config.example.toml`](../macrostrat-config.example.toml).
+
+## Usage
+
+See [the CLI docs](docs/cli-usage.md) for CLI functionality
+
+## Legacy
+
+The basis of the Macrostrat CLI is in Python scripts in the
+[`utils` repository](https://github.com/UW-Macrostrat/utils) that were used to
+control the Macrostrat map system starting in 2015, when **v1** of Macrostrat's
+map system was created. These scripts were used to manage the map system's
+database on a single server.
+
+As Macrostrat has transitioned to a more distributed set of containerized
+services, and less centralized workflows, the tight focus of the original CLI
+has become an difficult fit in our ecosystem. By making the tool pluggable and
+aware of different Macrostrat environments, we hope a renewed Macrostrat CLI can
+supply some broad organization to the platform's second act.
+
+## Architecture
+
+The Macrostrat CLI is a Python 3 package that can manage a containerized set of
+Macrostrat services, orchestrated in either Docker Compose or Kubernetes. The
+CLI is designed to be extensible, both to
+
+- Manage different Macrostrat environments, such as development, staging, and
+  production, and pass data between them
+- Manage Macrostrat services, including applications that are not part of every
+  Macrostrat installation (e.g., Paleogeography, Rockd, etc.)
+
+Most components of Macrostrat rely on specific capabilities and datasets within
+Macrostrat's core PostGIS database. Thus, the main focus of this tool is to
+shape and maintain the database and the data it contains. It also includes
+scripts for service inspection, deployment, orchestration, and other management
+utilities.
+
+**v2** of this system is in early development, and its management tools are both
+incomplete and relatively poorly tested. Many capabilities will be implemented
+within
+[Macrostrat's shared Python libraries](https://github.com/UW-Macrostrat/python-libraries),
+which will be used for other Macrostrat applications, such as
+[Sparrow](https://github.com/EarthCubeGeochron/Sparrow).

--- a/macrostrat-cli/docs/cli-usage.md
+++ b/macrostrat-cli/docs/cli-usage.md
@@ -1,0 +1,28 @@
+# Macrostrat command-line interface documentation
+
+Usage: `macrostrat <subcommand> [options]`
+
+## Subcommands
+
+- `db` - Manage the Macrostrat database
+- `env` - Manage Macrostrat environments
+- `self` - Inspect the command-line application
+
+...and others yet to be implemented
+
+## Database management
+
+- `macrostrat db dump [database?]`: Create a custom-format dump of the database
+- `macrostrat db restore <dumpfile> [database?]`: Restore a database from a
+  dumpfile
+- `macrostrat db psql [database?]`: Open a psql shell to the database. Also
+  supports piping SQL from stdin.
+- `macrostrat db update-schema`: run idempotent schema updates
+
+## Environment management
+
+- `macrostrat env`: Switch to another environment
+
+## Self-inspection
+
+- `macrostrat self`: Inspect the command-line application

--- a/macrostrat-cli/macrostrat_cli/_dev/dump_database.py
+++ b/macrostrat-cli/macrostrat_cli/_dev/dump_database.py
@@ -18,6 +18,7 @@ async def _pg_dump(
     args: list = [],
     postgres_container: str = "postgres:15",
     user: Optional[str] = "postgres",
+    stdout=asyncio.subprocess.PIPE
 ):
     command_prefix = command_prefix or _docker_local_run_args(postgres_container)
 
@@ -32,7 +33,7 @@ async def _pg_dump(
         "-Fc",
         str(engine.url),
         *_args,
-        stdout=asyncio.subprocess.PIPE,
+        stdout=stdout,
         stderr=asyncio.subprocess.PIPE,
     )
 

--- a/macrostrat-cli/macrostrat_cli/_dev/dump_database.py
+++ b/macrostrat-cli/macrostrat_cli/_dev/dump_database.py
@@ -6,6 +6,11 @@ import aiofiles
 from .utils import _docker_local_run_args, print_stream_progress, print_stdout
 
 
+def pg_dump(*args, **kwargs):
+    task = _pg_dump_to_file(*args, **kwargs)
+    asyncio.run(task)
+
+
 async def _pg_dump(
     engine: Engine,
     *,

--- a/macrostrat-cli/macrostrat_cli/_dev/restore_database.py
+++ b/macrostrat-cli/macrostrat_cli/_dev/restore_database.py
@@ -35,6 +35,12 @@ async def _pg_restore(
         console.print(f"Creating database [bold cyan]{database}[/]")
         create_database(database)
 
+    if not db_exists and not create:
+        raise ValueError(
+            f"Database [bold cyan]{database}[/] does not exist. "
+            "Use `--create` to create it."
+        )
+
     # Run pg_restore in a local Docker container
     # TODO: this could also be run with pg_restore in a Kubernetes pod
     # or another location, if more appropriate. Running on the remote

--- a/macrostrat-cli/macrostrat_cli/_dev/utils.py
+++ b/macrostrat-cli/macrostrat_cli/_dev/utils.py
@@ -24,7 +24,8 @@ async def print_stream_progress(
     async for line in in_stream:
         megabytes_written += len(line) / 1_000_000
         out_stream.write(line)
-        await out_stream.drain()
+        if hasattr(out_stream, "drain"):
+            await out_stream.drain()
         i += 1
         if i == 1000:
             i = 0

--- a/macrostrat-cli/macrostrat_cli/cli.py
+++ b/macrostrat-cli/macrostrat_cli/cli.py
@@ -1,7 +1,7 @@
 from dotenv import load_dotenv
 from pathlib import Path
 from os import environ
-from sys import stderr, argv
+from sys import stderr, argv, stdin
 from rich import print
 from typing import Optional
 import typer
@@ -170,7 +170,7 @@ def psql(ctx: typer.Context, database: str = None):
         "--network",
         "host",
     ]
-    if len(ctx.args) == 0:
+    if len(ctx.args) == 0 and stdin.isatty():
         flags.append("-t")
 
     run("docker", "run", *flags, "postgres:15", "psql", _database, *ctx.args)

--- a/macrostrat-cli/macrostrat_cli/cli.py
+++ b/macrostrat-cli/macrostrat_cli/cli.py
@@ -176,6 +176,29 @@ def psql(ctx: typer.Context, database: str = None):
     run("docker", "run", *flags, "postgres:15", "psql", _database, *ctx.args)
 
 
+@db_app.command(
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True}
+)
+def dump(
+    ctx: typer.Context,
+    dumpfile: Path,
+    database: str = None,
+):
+    """Dump the database to a file"""
+    from ._dev.dump_database import pg_dump
+
+    db_container = settings.get("pg_database_container", "postgres:15")
+
+    engine = _engine_for_db_name(database)
+
+    pg_dump(
+        dumpfile,
+        engine,
+        postgres_container=db_container,
+        args=ctx.args,
+    )
+
+
 @db_app.command()
 def restore(
     dumpfile: Path,

--- a/macrostrat.toml.example
+++ b/macrostrat.toml.example
@@ -1,0 +1,36 @@
+[default]
+# Source code for of individual services that we want to integrate
+# TODO: we may decide to organize these somewhat differently.
+corelle_src = "~/Projects/Macrostrat/Software/corelle"
+map_integration_src = "~/Projects/Macrostrat/Infrastructure/macrostrat/map-integration"
+
+# The remainder of the configuration expresses different settings per environment
+[local]
+# Example of changing the database container..
+pg_database_container = "imresamu/postgis:15-3.4"
+pg_database = "postgresql://macrostrat-admin:my-cool-password@localhost:5432/macrostrat"
+
+# Use a docker compose configuration (there will eventually be a bundled default)
+compose_root = "./local-root"
+
+# Key for salting passwords
+secret_key = "really-secure-key"
+
+# A separate database for map ingestionm, if desired
+ingestion_database = "map_ingestion"
+
+# A kubernetes based development instance
+[development]
+pg_database = "postgresql://macrostrat-admin:my-cool-password@dev.macrostrat.org:5432/macrostrat"
+# Use a Kubernetes namespace
+# Right now, using kubectl's default configuration and connection parameters is assumed
+# 
+kubernetes_namespace="<my-namespace>"
+pg_database_pod = "dev-macrostrat-db"
+
+# A hypothetical remote implementation
+# Fundamentally, the only required component is the database connection string
+# (service management features will not be available).
+[criticalmaas]
+
+pg_database = "postgresql://remote_user:remote_password@cool-other-server.usgs.gov:5432/criticalmaas_maps"


### PR DESCRIPTION
Created several utilities:
- `macrostrat db dump [database?]`
- `macrostrat db restore <dumpfile> [database?]`
- `macrostrat db psql [database?]`

These are thin wrappers around `pg_dump`, `pg_restore`, and `psql` respectively. They default to using the `pg_database`  value configured in settings.
