### PR TITLE
Updated asyncio chunk size for pg_restore

### DIFF
--- a/cli/macrostrat/cli/_dev/restore_database.py
+++ b/cli/macrostrat/cli/_dev/restore_database.py
@@ -47,7 +47,7 @@ async def _pg_restore(
         *_cmd,
         stdin=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
-        limit=1024 * 1024 * 10,  # 10 MB windows
+        limit=1024 * 1024 * 1,  # 1 MB windows
     )
 
 


### PR DESCRIPTION
- fixes #19
- this may not work for databases with unusually wide rows (e.g., `elevation`)