### PR TITLE
Fixes to the `ingest` command

### DIFF
--- a/map-integration/macrostrat/map_integration/commands/ingest.py
+++ b/map-integration/macrostrat/map_integration/commands/ingest.py
@@ -38,7 +38,7 @@ def ingest_map(
     frames = defaultdict(list)
 
     # Add to map-sources table
-    db.engine.execute(
+    db.run_sql(
         f"INSERT INTO maps.sources (primary_table) VALUES ('{source_id}') ON CONFLICT DO NOTHING"
     )
 
@@ -98,7 +98,7 @@ def ingest_map(
         table = f"{source_id}_{feature_type.lower()}s"
         schema = "sources"
 
-        db.engine.execute(f"CREATE SCHEMA IF NOT EXISTS {schema}")
+        db.run_sql(f"CREATE SCHEMA IF NOT EXISTS {schema}")
 
         console.print(f"Writing [blue dim]{schema}.{table}")
         # Get first 10 rows


### PR DESCRIPTION
I found two lingering instances of `db.engine.execute` and replaced them with `db.run_sql`.