### PR TITLE
Update the ingest script for SQLAlchemy 2 and new table structure

### DIFF
--- a/map-integration/macrostrat/map_integration/commands/ingest.py
+++ b/map-integration/macrostrat/map_integration/commands/ingest.py
@@ -39,7 +39,7 @@ def ingest_map(
 
     # Add to map-sources table
     db.run_sql(
-        f"INSERT INTO maps.sources (primary_table) VALUES ('{source_id}') ON CONFLICT DO NOTHING"
+        f"INSERT INTO maps.sources (primary_table, slug) VALUES ('{source_id}_polygons', '{source_id}') ON CONFLICT DO NOTHING"
     )
 
     for file in files:

--- a/map-integration/macrostrat/map_integration/commands/ingest.py
+++ b/map-integration/macrostrat/map_integration/commands/ingest.py
@@ -129,7 +129,7 @@ def ingest_map(
                 # Ensure multigeometries are used (brute force)
                 if i == 0:
                     conn.execute(
-                        f"ALTER TABLE {schema}.{table} ALTER COLUMN geometry TYPE Geometry(Geometry, 4326)"
+                        text(f"ALTER TABLE {schema}.{table} ALTER COLUMN geometry TYPE Geometry(Geometry, 4326)")
                     )
                 progress.update(task, advance=len(chunk))
 

--- a/map-integration/macrostrat/map_integration/commands/process/rgeom.py
+++ b/map-integration/macrostrat/map_integration/commands/process/rgeom.py
@@ -21,10 +21,10 @@ def create_rgeom(source_id: int):
     # TODO: figure out bug where we can't use $(primary_table)s here
     q = "UPDATE {primary_table} SET geom = ST_Buffer(geom, 0)"
     table = Identifier("sources", name)
-    db.run_query(q, {"primary_table": table})
+    db.run_sql(q, {"primary_table": table})
 
     print("Creating reference geometry...")
-    db.run_query(sql_file("set-rgeom"), dict(source_id=source_id, primary_table=table))
+    db.run_sql(sql_file("set-rgeom"), dict(source_id=source_id, primary_table=table))
 
     end = time.time()
 
@@ -34,4 +34,4 @@ def create_rgeom(source_id: int):
 def create_webgeom(source_id: int):
     """Create a geometry for use on the web"""
     sql = sql_file("set-webgeom")
-    db.run_query(sql, {"source_id": source_id})
+    db.run_sql(sql, {"source_id": source_id})

--- a/map-integration/macrostrat/map_integration/database.py
+++ b/map-integration/macrostrat/map_integration/database.py
@@ -17,4 +17,4 @@ def database_connection():
 
 def sql_file(key: str) -> str:
     """Return the contents of a SQL file."""
-    return Path(__file__).parent / "procedures" / (key + ".sql")
+    return (Path(__file__).parent / "procedures" / (key + ".sql")).read_text()


### PR DESCRIPTION
I've located a couple more spots in the `ingest` script that needed updating.

The update to populate the `slug` is based on [Cannon's version of the script](https://github.com/CannonLock/map-ingestion/blob/00ad1d41153bb0c1dfcabb652519156b5541e73a/macrostrat/map_integration/commands/ingest.py#L40).

The added `text` wrapper resolves a [ObjectNotExecutableError](https://stackoverflow.com/questions/69490450/objectnotexecutableerror-when-executing-any-sql-query-using-asyncengine) from SQLAlchemy.