### PR TITLE
Storage management scripts

### DIFF
--- a/cli/macrostrat/cli/cli.py
+++ b/cli/macrostrat/cli/cli.py
@@ -1,20 +1,16 @@
-import json
 from os import environ
 from pathlib import Path
-from typing import Optional
 
 import typer
+from macrostrat.utils.shell import run
 from rich import print
 from rich.traceback import install
-from typer import Argument, Option, Typer
+from typer import Argument, Typer
 
 from macrostrat.core import app
-from macrostrat.core.exc import MacrostratError, setup_exception_handling
+from macrostrat.core.exc import MacrostratError
 from macrostrat.core.main import env_text, set_app_state
-from macrostrat.utils.shell import run
-
 from .database import db_app, db_subsystem
-from .kubernetes import get_secret
 from .subsystems.macrostrat_api import MacrostratAPISubsystem
 from .subsystems.paleogeography import load_paleogeography_subsystem
 from .v1_entrypoint import v1_cli
@@ -242,7 +238,8 @@ try:
     db_subsystem.register_schema_part(name="tileserver", callback=update_tileserver)
 
 except ImportError as err:
-    app.console.print("Could not import tileserver subsystem")
+    pass
+    # app.console.print("Could not import tileserver subsystem")
 
 # Get subsystems config
 subsystems = getattr(settings, "subsystems", {})
@@ -265,6 +262,7 @@ app = load_paleogeography_subsystem(app, main, db_subsystem)
 
 if mapboard_url := getattr(settings, "mapboard_database", None):
     from .subsystems.mapboard import MapboardSubsystem
+
     app.subsystems.add(MapboardSubsystem(app))
 
 try:

--- a/cli/macrostrat/cli/cli.py
+++ b/cli/macrostrat/cli/cli.py
@@ -260,12 +260,7 @@ if subsystems.get("criticalmaas", False):
 app = load_paleogeography_subsystem(app, main, db_subsystem)
 
 
-if mapboard_url := getattr(settings, "mapboard_database", None):
-    from .subsystems.mapboard import MapboardSubsystem
-
-    app.subsystems.add(MapboardSubsystem(app))
-
-try:
+if kube_namespace := getattr(settings, "kube_namespace", None):
     from .kubernetes import app as kube_app
 
     main.add_typer(
@@ -274,11 +269,18 @@ try:
         short_help="Kubernetes utilities",
         rich_help_panel="Subsystems",
     )
-except ImportError as err:
-    print("Could not import Kubernetes subsystem")
 
 
-# Add other subsystems (temporary)
+from .subsystems.storage import app as storage_app
+
+main.add_typer(
+    storage_app,
+    name="storage",
+    short_help="Manage storage buckets",
+    rich_help_panel="Subsystems",
+)
+
+
 from .subsystems.mapboard import MapboardSubsystem
 
 if subsystems.get("mapboard", False):

--- a/cli/macrostrat/cli/cli.py
+++ b/cli/macrostrat/cli/cli.py
@@ -72,13 +72,6 @@ main.add_typer(
 
 
 @main.command()
-def secrets(secret_name: Optional[str] = Argument(None), *, key: str = Option(None)):
-    """Get a secret from the Kubernetes cluster"""
-
-    print(json.dumps(get_secret(settings, secret_name, secret_key=key), indent=4))
-
-
-@main.command()
 def shell():
     """Start an IPython shell"""
     import IPython
@@ -272,8 +265,21 @@ app = load_paleogeography_subsystem(app, main, db_subsystem)
 
 if mapboard_url := getattr(settings, "mapboard_database", None):
     from .subsystems.mapboard import MapboardSubsystem
-
     app.subsystems.add(MapboardSubsystem(app))
+
+try:
+    from .kubernetes import app as kube_app
+
+    main.add_typer(
+        kube_app,
+        name="kube",
+        short_help="Kubernetes utilities",
+        rich_help_panel="Subsystems",
+    )
+except ImportError as err:
+    print("Could not import Kubernetes subsystem")
+
+
 # Add other subsystems (temporary)
 from .subsystems.mapboard import MapboardSubsystem
 

--- a/cli/macrostrat/cli/database/__init__.py
+++ b/cli/macrostrat/cli/database/__init__.py
@@ -116,14 +116,16 @@ class DatabaseSubsystem(MacrostratSubsystem):
 
         self.schema_hunks.append(hunk)
 
+    def initialize(self):
+        self.register_schema_part(
+            name="core",
+            fixtures=[fixtures_dir],
+        )
+
 
 db_subsystem = DatabaseSubsystem(app)
 
-
-db_subsystem.register_schema_part(
-    name="core",
-    fixtures=[fixtures_dir],
-)
+db_app = typer.Typer(no_args_is_help=True)
 
 
 def update_schema(
@@ -134,6 +136,8 @@ def update_schema(
     """Update the database schema"""
     from macrostrat.core.config import PG_DATABASE
     from macrostrat.database import Database
+
+    db_subsystem = app.subsystems.get("database")
 
     """Create schema additions"""
     schema_dir = fixtures_dir

--- a/cli/macrostrat/cli/kubernetes/__init__.py
+++ b/cli/macrostrat/cli/kubernetes/__init__.py
@@ -8,10 +8,10 @@ from os import environ
 from subprocess import run
 from typing import Optional, List
 
-from macrostrat.core import app as app_
 from rich import print
-from typer import Argument, Option
-from typer import Typer
+from typer import Argument, Option, Typer
+
+from macrostrat.core import app as app_
 
 settings = app_.settings
 
@@ -72,7 +72,7 @@ def get_secret(settings, secret_name: Optional[str], *, secret_key: str = None):
     return secret
 
 
-app = Typer()
+app = Typer(no_args_is_help=True)
 
 
 @app.command()
@@ -109,7 +109,8 @@ def s3_users():
 
 
 @app.command(
-    context_settings={"allow_extra_args": True, "ignore_unknown_options": True}
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+    add_help_option=False,
 )
 def mc(args: List[str] = Argument(None)):
     """
@@ -140,6 +141,10 @@ def _mc(command: str, **kwargs):
         _script.append(
             f"mc alias set {user} {endpoint} {access_key} {secret_key} --api s3v4 > /dev/null 2>&1"
         )
+
+    # Delete common aliases
+    for alias in ["gcs", "local", "play", "s3"]:
+        _script.append(f"mc alias remove {alias} > /dev/null 2>&1")
 
     _script.append(command)
     script = "\n".join(_script)

--- a/cli/macrostrat/cli/kubernetes/__init__.py
+++ b/cli/macrostrat/cli/kubernetes/__init__.py
@@ -4,7 +4,6 @@ Functions for working with a Macrostrat instance in a Kubernetes cluster.
 
 import base64
 import json
-from contextlib import contextmanager
 from os import environ
 from subprocess import run
 from typing import Optional
@@ -22,11 +21,26 @@ def read_secret(text):
     return secret
 
 
-def get_secret(settings, secret_name: Optional[str], *, secret_key: str = None):
+def _kubectl(settings, args, **kwargs):
+    """
+    Run a kubectl command.
+    """
     namespace = getattr(settings, "kube_namespace", None)
     if namespace is None:
         raise Exception("No Kubernetes namespace specified.")
 
+    proxy = getattr(settings, "kube_proxy", None)
+    env = environ
+    if proxy:
+        env = {
+            **env,
+            "HTTPS_PROXY": proxy,
+            "HTTP_PROXY": proxy,
+        }
+    return run(["kubectl", *args], env=env, **kwargs)
+
+
+def get_secret(settings, secret_name: Optional[str], *, secret_key: str = None):
     args = []
     if secret_name is not None:
         args = [
@@ -35,7 +49,9 @@ def get_secret(settings, secret_name: Optional[str], *, secret_key: str = None):
             "json",
         ]
 
-    password = run(["kubectl", "get", "secrets", *args], capture_output=True, text=True)
+    password = _kubectl(
+        settings, ["get", "secrets", *args], capture_output=True, text=True
+    )
 
     if secret_name is None:
         return password.stdout
@@ -47,3 +63,109 @@ def get_secret(settings, secret_name: Optional[str], *, secret_key: str = None):
     for key in keys:
         secret = secret[key]
     return secret
+
+
+app = Typer()
+
+
+@app.command()
+def secrets(secret_name: Optional[str] = Argument(None), *, key: str = Option(None)):
+    """Get a secret from the Kubernetes cluster"""
+
+    if secret_name is None:
+        print("Available secrets:")
+        print(get_secret(settings, None))
+        return
+
+    print(json.dumps(get_secret(settings, secret_name, secret_key=key), indent=4))
+
+
+@app.command()
+def mirror_bucket(
+    src: Optional[str] = Argument(None),
+    dst: Optional[str] = Argument(None),
+    user=None,
+    overwrite=False,
+):
+    """
+    Mirror two S3 buckets using a worker on the Kubernetes cluster.
+    """
+    # Build and run a Docker container with mc
+
+    op = f"mirror src/{src} src/{dst}"
+    if overwrite:
+        op += " --overwrite"
+
+    if src is None and dst is None:
+        print("No source or destination bucket specified.")
+        op = "ls src"
+
+    if user is None:
+        raise Exception("Must specify a S3 user name.")
+
+    cfg = get_secret(settings, "s3-user-" + user)
+
+    script = f"""
+    mc alias set src {getattr(settings, "s3_endpoint")} {cfg["access_key"]} {cfg["secret_key"]} --api s3v4
+    mc {op}
+    """
+
+    run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-t",
+            "--entrypoint=/bin/sh",
+            "minio/mc:latest",
+            "-c",
+            script,
+        ],
+        env={
+            "DOCKER_HOST": getattr(
+                settings, "docker_base_url", "unix://var/run/docker.sock"
+            ),
+            **environ,
+        },
+    )
+
+    # Redirect stderr to devnull
+    # _stderr = sys.stderr
+    # sys.stderr = open(devnull, "w")
+    # docker = DockerClient(
+    #     base_url=getattr(settings, "docker_base_url", "unix://var/run/docker.sock"),
+    #     use_ssh_client=True,
+    # )
+    #
+    # res = docker.containers.run(
+    #     "minio/mc:latest",
+    #     command=["-c", script],
+    #     remove=True,
+    #     detach=False,
+    #     entrypoint="/bin/sh",
+    #     stdout=True,
+    #     stderr=False,
+    #     tty=True,
+    # )
+    # print(res.decode("utf-8"))
+    #
+    # # Restore stderr
+    # sys.stderr = _stderr
+
+    # _kubectl(
+    #     settings,
+    #     [
+    #         "run",
+    #         "s3-mirror",
+    #         "--restart=Never",
+    #         "--image=docker.io/minio/mc:latest",
+    #         "--rm",
+    #         "--command",
+    #         "--attach",
+    #         "--",
+    #         "echo",
+    #         "Hello, world!",
+    #         # "-c",
+    #         # script,
+    #     ],
+    # )

--- a/cli/macrostrat/cli/rockd.py
+++ b/cli/macrostrat/cli/rockd.py
@@ -1,0 +1,3 @@
+"""
+Sync Rockd data files
+"""

--- a/cli/macrostrat/cli/subsystems/sgp/__init__.py
+++ b/cli/macrostrat/cli/subsystems/sgp/__init__.py
@@ -7,6 +7,10 @@ from typer import Typer
 from .match import import_sgp_data
 from .paleogeography import compute_paleo_positions
 
-sgp = Typer(name="sgp", no_args_is_help=True)
+sgp = Typer(
+    name="sgp",
+    no_args_is_help=True,
+    short_help="Sedimentary Geochemistry and Paleogeography integration",
+)
 sgp.command(name="match-units")(import_sgp_data)
 sgp.command(name="paleogeography")(compute_paleo_positions)

--- a/cli/macrostrat/cli/subsystems/storage.py
+++ b/cli/macrostrat/cli/subsystems/storage.py
@@ -1,0 +1,129 @@
+"""
+Storage system management
+"""
+
+from os import environ
+from subprocess import run
+from typing import Optional, List
+
+from macrostrat.utils import get_logger
+from rich import print
+from typer import Argument, Option, Typer
+
+from macrostrat.core import app as app_
+from ..kubernetes import get_secret, _kubectl
+
+settings = app_.settings
+
+log = get_logger(__name__)
+
+
+app = Typer(no_args_is_help=True)
+
+
+def _s3_users():
+    res = _kubectl(
+        settings,
+        ["get", "secrets", "-o", "jsonpath={.items[*].metadata.name}"],
+        capture_output=True,
+        text=True,
+    )
+    prefix = "s3-user-"
+    return [
+        r.replace(prefix, "") for r in res.stdout.split(" ") if r.startswith(prefix)
+    ]
+
+
+@app.command()
+def users():
+    """
+    List available S3 users.
+    """
+    print(_s3_users())
+
+
+@app.command(
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+    add_help_option=False,
+)
+def mc(args: List[str] = Argument(None)):
+    """
+    Run the Minio client in a Docker container.
+    """
+
+    script = "mc"
+    if args is not None:
+        script += " " + " ".join(args)
+
+    _mc(script)
+
+
+def _mc(command: str, **kwargs):
+    """
+    Run the Minio client in a Docker container.
+    """
+    _script = []
+    for user in _s3_users():
+        cfg = get_secret(settings, "s3-user-" + user)
+        if cfg is None:
+            raise Exception(f"No secret found for S3 user {user}.")
+
+        access_key = cfg["access_key"]
+        secret_key = cfg["secret_key"]
+        endpoint = getattr(settings, "s3_endpoint")
+
+        _script.append(
+            f"mc alias set {user} {endpoint} {access_key} {secret_key} --api s3v4 > /dev/null 2>&1"
+        )
+
+    # Delete common aliases
+    for alias in ["gcs", "local", "play", "s3"]:
+        _script.append(f"mc alias remove {alias} > /dev/null 2>&1")
+
+    _script.append(command)
+    script = "\n".join(_script)
+
+    host = getattr(settings, "docker_base_url", "unix://var/run/docker.sock")
+
+    log.info(f"Running Minio client in Docker host {host}")
+
+    return run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-it",
+            "--entrypoint=/bin/sh",
+            "minio/mc:latest",
+            "-c",
+            script,
+        ],
+        env={
+            "DOCKER_HOST": host,
+            **environ,
+        },
+        **kwargs,
+    )
+
+
+@app.command()
+def mirror(
+    src: Optional[str] = Argument(None),
+    dst: Optional[str] = Argument(None),
+    overwrite=Option(False, help="Overwrite existing files"),
+):
+    """
+    Mirror two buckets using a worker
+    """
+    # Build and run a Docker container with mc
+
+    if src is None or dst is None:
+        raise Exception("Both source and destination buckets must be specified.")
+
+    flags = ""
+    if overwrite:
+        flags = "--overwrite"
+
+    script = "\n".join([f"mc mb {dst}", f"mc mirror {flags} {src} {dst}"])
+
+    _mc(script)

--- a/cli/poetry.lock
+++ b/cli/poetry.lock
@@ -117,6 +117,46 @@ tests = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4
 tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 
 [[package]]
+name = "bcrypt"
+version = "4.1.3"
+description = "Modern password hashing for your software and your servers"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "bcrypt-4.1.3-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:48429c83292b57bf4af6ab75809f8f4daf52aa5d480632e53707805cc1ce9b74"},
+    {file = "bcrypt-4.1.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4a8bea4c152b91fd8319fef4c6a790da5c07840421c2b785084989bf8bbb7455"},
+    {file = "bcrypt-4.1.3-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d3b317050a9a711a5c7214bf04e28333cf528e0ed0ec9a4e55ba628d0f07c1a"},
+    {file = "bcrypt-4.1.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:094fd31e08c2b102a14880ee5b3d09913ecf334cd604af27e1013c76831f7b05"},
+    {file = "bcrypt-4.1.3-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:4fb253d65da30d9269e0a6f4b0de32bd657a0208a6f4e43d3e645774fb5457f3"},
+    {file = "bcrypt-4.1.3-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:193bb49eeeb9c1e2db9ba65d09dc6384edd5608d9d672b4125e9320af9153a15"},
+    {file = "bcrypt-4.1.3-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:8cbb119267068c2581ae38790e0d1fbae65d0725247a930fc9900c285d95725d"},
+    {file = "bcrypt-4.1.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6cac78a8d42f9d120b3987f82252bdbeb7e6e900a5e1ba37f6be6fe4e3848286"},
+    {file = "bcrypt-4.1.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:01746eb2c4299dd0ae1670234bf77704f581dd72cc180f444bfe74eb80495b64"},
+    {file = "bcrypt-4.1.3-cp37-abi3-win32.whl", hash = "sha256:037c5bf7c196a63dcce75545c8874610c600809d5d82c305dd327cd4969995bf"},
+    {file = "bcrypt-4.1.3-cp37-abi3-win_amd64.whl", hash = "sha256:8a893d192dfb7c8e883c4576813bf18bb9d59e2cfd88b68b725990f033f1b978"},
+    {file = "bcrypt-4.1.3-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0d4cf6ef1525f79255ef048b3489602868c47aea61f375377f0d00514fe4a78c"},
+    {file = "bcrypt-4.1.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f5698ce5292a4e4b9e5861f7e53b1d89242ad39d54c3da451a93cac17b61921a"},
+    {file = "bcrypt-4.1.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec3c2e1ca3e5c4b9edb94290b356d082b721f3f50758bce7cce11d8a7c89ce84"},
+    {file = "bcrypt-4.1.3-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:3a5be252fef513363fe281bafc596c31b552cf81d04c5085bc5dac29670faa08"},
+    {file = "bcrypt-4.1.3-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:5f7cd3399fbc4ec290378b541b0cf3d4398e4737a65d0f938c7c0f9d5e686611"},
+    {file = "bcrypt-4.1.3-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:c4c8d9b3e97209dd7111bf726e79f638ad9224b4691d1c7cfefa571a09b1b2d6"},
+    {file = "bcrypt-4.1.3-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:31adb9cbb8737a581a843e13df22ffb7c84638342de3708a98d5c986770f2834"},
+    {file = "bcrypt-4.1.3-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:551b320396e1d05e49cc18dd77d970accd52b322441628aca04801bbd1d52a73"},
+    {file = "bcrypt-4.1.3-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6717543d2c110a155e6821ce5670c1f512f602eabb77dba95717ca76af79867d"},
+    {file = "bcrypt-4.1.3-cp39-abi3-win32.whl", hash = "sha256:6004f5229b50f8493c49232b8e75726b568535fd300e5039e255d919fc3a07f2"},
+    {file = "bcrypt-4.1.3-cp39-abi3-win_amd64.whl", hash = "sha256:2505b54afb074627111b5a8dc9b6ae69d0f01fea65c2fcaea403448c503d3991"},
+    {file = "bcrypt-4.1.3-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:cb9c707c10bddaf9e5ba7cdb769f3e889e60b7d4fea22834b261f51ca2b89fed"},
+    {file = "bcrypt-4.1.3-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:9f8ea645eb94fb6e7bea0cf4ba121c07a3a182ac52876493870033141aa687bc"},
+    {file = "bcrypt-4.1.3-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:f44a97780677e7ac0ca393bd7982b19dbbd8d7228c1afe10b128fd9550eef5f1"},
+    {file = "bcrypt-4.1.3-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d84702adb8f2798d813b17d8187d27076cca3cd52fe3686bb07a9083930ce650"},
+    {file = "bcrypt-4.1.3.tar.gz", hash = "sha256:2ee15dd749f5952fe3f0430d0ff6b74082e159c50332a1413d51b5689cf06623"},
+]
+
+[package.extras]
+tests = ["pytest (>=3.2.1,!=3.3.0)"]
+typecheck = ["mypy"]
+
+[[package]]
 name = "certifi"
 version = "2024.8.30"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -201,6 +241,70 @@ files = [
     {file = "cffi-1.17.1-cp39-cp39-win32.whl", hash = "sha256:e31ae45bc2e29f6b2abd0de1cc3b9d5205aa847cafaecb8af1476a609a2f6eb7"},
     {file = "cffi-1.17.1-cp39-cp39-win_amd64.whl", hash = "sha256:d016c76bdd850f3c626af19b0542c9677ba156e4ee4fccfdd7848803533ef662"},
     {file = "cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824"},
+]
+
+[package.dependencies]
+pycparser = "*"
+
+[[package]]
+name = "cffi"
+version = "1.16.0"
+description = "Foreign Function Interface for Python calling C code."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "cffi-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6b3d6606d369fc1da4fd8c357d026317fbb9c9b75d36dc16e90e84c26854b088"},
+    {file = "cffi-1.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ac0f5edd2360eea2f1daa9e26a41db02dd4b0451b48f7c318e217ee092a213e9"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7e61e3e4fa664a8588aa25c883eab612a188c725755afff6289454d6362b9673"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a72e8961a86d19bdb45851d8f1f08b041ea37d2bd8d4fd19903bc3083d80c896"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b50bf3f55561dac5438f8e70bfcdfd74543fd60df5fa5f62d94e5867deca684"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7651c50c8c5ef7bdb41108b7b8c5a83013bfaa8a935590c5d74627c047a583c7"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4108df7fe9b707191e55f33efbcb2d81928e10cea45527879a4749cbe472614"},
+    {file = "cffi-1.16.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:32c68ef735dbe5857c810328cb2481e24722a59a2003018885514d4c09af9743"},
+    {file = "cffi-1.16.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:673739cb539f8cdaa07d92d02efa93c9ccf87e345b9a0b556e3ecc666718468d"},
+    {file = "cffi-1.16.0-cp310-cp310-win32.whl", hash = "sha256:9f90389693731ff1f659e55c7d1640e2ec43ff725cc61b04b2f9c6d8d017df6a"},
+    {file = "cffi-1.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:e6024675e67af929088fda399b2094574609396b1decb609c55fa58b028a32a1"},
+    {file = "cffi-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b84834d0cf97e7d27dd5b7f3aca7b6e9263c56308ab9dc8aae9784abb774d404"},
+    {file = "cffi-1.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1b8ebc27c014c59692bb2664c7d13ce7a6e9a629be20e54e7271fa696ff2b417"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ee07e47c12890ef248766a6e55bd38ebfb2bb8edd4142d56db91b21ea68b7627"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8a9d3ebe49f084ad71f9269834ceccbf398253c9fac910c4fd7053ff1386936"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e70f54f1796669ef691ca07d046cd81a29cb4deb1e5f942003f401c0c4a2695d"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5bf44d66cdf9e893637896c7faa22298baebcd18d1ddb6d2626a6e39793a1d56"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b78010e7b97fef4bee1e896df8a4bbb6712b7f05b7ef630f9d1da00f6444d2e"},
+    {file = "cffi-1.16.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:c6a164aa47843fb1b01e941d385aab7215563bb8816d80ff3a363a9f8448a8dc"},
+    {file = "cffi-1.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e09f3ff613345df5e8c3667da1d918f9149bd623cd9070c983c013792a9a62eb"},
+    {file = "cffi-1.16.0-cp311-cp311-win32.whl", hash = "sha256:2c56b361916f390cd758a57f2e16233eb4f64bcbeee88a4881ea90fca14dc6ab"},
+    {file = "cffi-1.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:db8e577c19c0fda0beb7e0d4e09e0ba74b1e4c092e0e40bfa12fe05b6f6d75ba"},
+    {file = "cffi-1.16.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:fa3a0128b152627161ce47201262d3140edb5a5c3da88d73a1b790a959126956"},
+    {file = "cffi-1.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:68e7c44931cc171c54ccb702482e9fc723192e88d25a0e133edd7aff8fcd1f6e"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:abd808f9c129ba2beda4cfc53bde801e5bcf9d6e0f22f095e45327c038bfe68e"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:88e2b3c14bdb32e440be531ade29d3c50a1a59cd4e51b1dd8b0865c54ea5d2e2"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fcc8eb6d5902bb1cf6dc4f187ee3ea80a1eba0a89aba40a5cb20a5087d961357"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b7be2d771cdba2942e13215c4e340bfd76398e9227ad10402a8767ab1865d2e6"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e715596e683d2ce000574bae5d07bd522c781a822866c20495e52520564f0969"},
+    {file = "cffi-1.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2d92b25dbf6cae33f65005baf472d2c245c050b1ce709cc4588cdcdd5495b520"},
+    {file = "cffi-1.16.0-cp312-cp312-win32.whl", hash = "sha256:b2ca4e77f9f47c55c194982e10f058db063937845bb2b7a86c84a6cfe0aefa8b"},
+    {file = "cffi-1.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:68678abf380b42ce21a5f2abde8efee05c114c2fdb2e9eef2efdb0257fba1235"},
+    {file = "cffi-1.16.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0c9ef6ff37e974b73c25eecc13952c55bceed9112be2d9d938ded8e856138bcc"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a09582f178759ee8128d9270cd1344154fd473bb77d94ce0aeb2a93ebf0feaf0"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e760191dd42581e023a68b758769e2da259b5d52e3103c6060ddc02c9edb8d7b"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:80876338e19c951fdfed6198e70bc88f1c9758b94578d5a7c4c91a87af3cf31c"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a6a14b17d7e17fa0d207ac08642c8820f84f25ce17a442fd15e27ea18d67c59b"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6602bc8dc6f3a9e02b6c22c4fc1e47aa50f8f8e6d3f78a5e16ac33ef5fefa324"},
+    {file = "cffi-1.16.0-cp38-cp38-win32.whl", hash = "sha256:131fd094d1065b19540c3d72594260f118b231090295d8c34e19a7bbcf2e860a"},
+    {file = "cffi-1.16.0-cp38-cp38-win_amd64.whl", hash = "sha256:31d13b0f99e0836b7ff893d37af07366ebc90b678b6664c955b54561fc36ef36"},
+    {file = "cffi-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:582215a0e9adbe0e379761260553ba11c58943e4bbe9c36430c4ca6ac74b15ed"},
+    {file = "cffi-1.16.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b29ebffcf550f9da55bec9e02ad430c992a87e5f512cd63388abb76f1036d8d2"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dc9b18bf40cc75f66f40a7379f6a9513244fe33c0e8aa72e2d56b0196a7ef872"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cb4a35b3642fc5c005a6755a5d17c6c8b6bcb6981baf81cea8bfbc8903e8ba8"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b86851a328eedc692acf81fb05444bdf1891747c25af7529e39ddafaf68a4f3f"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c0f31130ebc2d37cdd8e44605fb5fa7ad59049298b3f745c74fa74c62fbfcfc4"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f8e709127c6c77446a8c0a8c8bf3c8ee706a06cd44b1e827c3e6a2ee6b8c098"},
+    {file = "cffi-1.16.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:748dcd1e3d3d7cd5443ef03ce8685043294ad6bd7c02a38d1bd367cfd968e000"},
+    {file = "cffi-1.16.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8895613bcc094d4a1b2dbe179d88d7fb4a15cee43c052e8885783fac397d91fe"},
+    {file = "cffi-1.16.0-cp39-cp39-win32.whl", hash = "sha256:ed86a35631f7bfbb28e108dd96773b9d5a6ce4811cf6ea468bb6a359b256b1e4"},
+    {file = "cffi-1.16.0-cp39-cp39-win_amd64.whl", hash = "sha256:3686dffb02459559c74dd3d81748269ffb0eb027c39a6fc99502de37d501faa8"},
+    {file = "cffi-1.16.0.tar.gz", hash = "sha256:bcb3ef43e58665bbda2fb198698fcae6776483e0c4a631aa5647806c25e02cc0"},
 ]
 
 [package.dependencies]
@@ -412,6 +516,60 @@ geopandas = ">=0.14.1,<0.15.0"
 "macrostrat.database" = ">=3.1.2,<4.0.0"
 macrostrat-utils = ">=1.2.0,<2.0.0"
 pyogrio = ">=0.7.2,<0.8.0"
+
+[[package]]
+name = "cryptography"
+version = "42.0.8"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "cryptography-42.0.8-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:81d8a521705787afe7a18d5bfb47ea9d9cc068206270aad0b96a725022e18d2e"},
+    {file = "cryptography-42.0.8-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:961e61cefdcb06e0c6d7e3a1b22ebe8b996eb2bf50614e89384be54c48c6b63d"},
+    {file = "cryptography-42.0.8-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e3ec3672626e1b9e55afd0df6d774ff0e953452886e06e0f1eb7eb0c832e8902"},
+    {file = "cryptography-42.0.8-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e599b53fd95357d92304510fb7bda8523ed1f79ca98dce2f43c115950aa78801"},
+    {file = "cryptography-42.0.8-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5226d5d21ab681f432a9c1cf8b658c0cb02533eece706b155e5fbd8a0cdd3949"},
+    {file = "cryptography-42.0.8-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6b7c4f03ce01afd3b76cf69a5455caa9cfa3de8c8f493e0d3ab7d20611c8dae9"},
+    {file = "cryptography-42.0.8-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:2346b911eb349ab547076f47f2e035fc8ff2c02380a7cbbf8d87114fa0f1c583"},
+    {file = "cryptography-42.0.8-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:ad803773e9df0b92e0a817d22fd8a3675493f690b96130a5e24f1b8fabbea9c7"},
+    {file = "cryptography-42.0.8-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2f66d9cd9147ee495a8374a45ca445819f8929a3efcd2e3df6428e46c3cbb10b"},
+    {file = "cryptography-42.0.8-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d45b940883a03e19e944456a558b67a41160e367a719833c53de6911cabba2b7"},
+    {file = "cryptography-42.0.8-cp37-abi3-win32.whl", hash = "sha256:a0c5b2b0585b6af82d7e385f55a8bc568abff8923af147ee3c07bd8b42cda8b2"},
+    {file = "cryptography-42.0.8-cp37-abi3-win_amd64.whl", hash = "sha256:57080dee41209e556a9a4ce60d229244f7a66ef52750f813bfbe18959770cfba"},
+    {file = "cryptography-42.0.8-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:dea567d1b0e8bc5764b9443858b673b734100c2871dc93163f58c46a97a83d28"},
+    {file = "cryptography-42.0.8-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c4783183f7cb757b73b2ae9aed6599b96338eb957233c58ca8f49a49cc32fd5e"},
+    {file = "cryptography-42.0.8-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0608251135d0e03111152e41f0cc2392d1e74e35703960d4190b2e0f4ca9c70"},
+    {file = "cryptography-42.0.8-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:dc0fdf6787f37b1c6b08e6dfc892d9d068b5bdb671198c72072828b80bd5fe4c"},
+    {file = "cryptography-42.0.8-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:9c0c1716c8447ee7dbf08d6db2e5c41c688544c61074b54fc4564196f55c25a7"},
+    {file = "cryptography-42.0.8-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:fff12c88a672ab9c9c1cf7b0c80e3ad9e2ebd9d828d955c126be4fd3e5578c9e"},
+    {file = "cryptography-42.0.8-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:cafb92b2bc622cd1aa6a1dce4b93307792633f4c5fe1f46c6b97cf67073ec961"},
+    {file = "cryptography-42.0.8-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:31f721658a29331f895a5a54e7e82075554ccfb8b163a18719d342f5ffe5ecb1"},
+    {file = "cryptography-42.0.8-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b297f90c5723d04bcc8265fc2a0f86d4ea2e0f7ab4b6994459548d3a6b992a14"},
+    {file = "cryptography-42.0.8-cp39-abi3-win32.whl", hash = "sha256:2f88d197e66c65be5e42cd72e5c18afbfae3f741742070e3019ac8f4ac57262c"},
+    {file = "cryptography-42.0.8-cp39-abi3-win_amd64.whl", hash = "sha256:fa76fbb7596cc5839320000cdd5d0955313696d9511debab7ee7278fc8b5c84a"},
+    {file = "cryptography-42.0.8-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:ba4f0a211697362e89ad822e667d8d340b4d8d55fae72cdd619389fb5912eefe"},
+    {file = "cryptography-42.0.8-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:81884c4d096c272f00aeb1f11cf62ccd39763581645b0812e99a91505fa48e0c"},
+    {file = "cryptography-42.0.8-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:c9bb2ae11bfbab395bdd072985abde58ea9860ed84e59dbc0463a5d0159f5b71"},
+    {file = "cryptography-42.0.8-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:7016f837e15b0a1c119d27ecd89b3515f01f90a8615ed5e9427e30d9cdbfed3d"},
+    {file = "cryptography-42.0.8-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5a94eccb2a81a309806027e1670a358b99b8fe8bfe9f8d329f27d72c094dde8c"},
+    {file = "cryptography-42.0.8-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:dec9b018df185f08483f294cae6ccac29e7a6e0678996587363dc352dc65c842"},
+    {file = "cryptography-42.0.8-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:343728aac38decfdeecf55ecab3264b015be68fc2816ca800db649607aeee648"},
+    {file = "cryptography-42.0.8-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:013629ae70b40af70c9a7a5db40abe5d9054e6f4380e50ce769947b73bf3caad"},
+    {file = "cryptography-42.0.8.tar.gz", hash = "sha256:8d09d05439ce7baa8e9e95b07ec5b6c886f548deb7e0f69ef25f64b3bce842f2"},
+]
+
+[package.dependencies]
+cffi = {version = ">=1.12", markers = "platform_python_implementation != \"PyPy\""}
+
+[package.extras]
+docs = ["sphinx (>=5.3.0)", "sphinx-rtd-theme (>=1.1.1)"]
+docstest = ["pyenchant (>=1.6.11)", "readme-renderer", "sphinxcontrib-spelling (>=4.0.1)"]
+nox = ["nox"]
+pep8test = ["check-sdist", "click", "mypy", "ruff"]
+sdist = ["build"]
+ssh = ["bcrypt (>=3.1.5)"]
+test = ["certifi", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist"]
+test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "decorator"
@@ -1095,6 +1253,27 @@ test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)"]
 xml = ["lxml (>=4.9.2)"]
 
 [[package]]
+name = "paramiko"
+version = "3.4.0"
+description = "SSH2 protocol library"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "paramiko-3.4.0-py3-none-any.whl", hash = "sha256:43f0b51115a896f9c00f59618023484cb3a14b98bbceab43394a39c6739b7ee7"},
+    {file = "paramiko-3.4.0.tar.gz", hash = "sha256:aac08f26a31dc4dffd92821527d1682d99d52f9ef6851968114a8728f3c274d3"},
+]
+
+[package.dependencies]
+bcrypt = ">=3.2"
+cryptography = ">=3.3"
+pynacl = ">=1.5"
+
+[package.extras]
+all = ["gssapi (>=1.4.1)", "invoke (>=2.0)", "pyasn1 (>=0.1.7)", "pywin32 (>=2.1.8)"]
+gssapi = ["gssapi (>=1.4.1)", "pyasn1 (>=0.1.7)", "pywin32 (>=2.1.8)"]
+invoke = ["invoke (>=2.0)"]
+
+[[package]]
 name = "parso"
 version = "0.8.4"
 description = "A Python Parser"
@@ -1242,6 +1421,17 @@ files = [
 
 [package.extras]
 tests = ["pytest"]
+
+[[package]]
+name = "pycparser"
+version = "2.22"
+description = "C parser in Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
+    {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
+]
 
 [[package]]
 name = "pycparser"
@@ -1446,6 +1636,32 @@ files = [
 [package.extras]
 ed25519 = ["PyNaCl (>=1.4.0)"]
 rsa = ["cryptography"]
+
+[[package]]
+name = "pynacl"
+version = "1.5.0"
+description = "Python binding to the Networking and Cryptography (NaCl) library"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "PyNaCl-1.5.0-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:401002a4aaa07c9414132aaed7f6836ff98f59277a234704ff66878c2ee4a0d1"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:52cb72a79269189d4e0dc537556f4740f7f0a9ec41c1322598799b0bdad4ef92"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a36d4a9dda1f19ce6e03c9a784a2921a4b726b02e1c736600ca9c22029474394"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:0c84947a22519e013607c9be43706dd42513f9e6ae5d39d3613ca1e142fba44d"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06b8f6fa7f5de8d5d2f7573fe8c863c051225a27b61e6860fd047b1775807858"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:a422368fc821589c228f4c49438a368831cb5bbc0eab5ebe1d7fac9dded6567b"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:61f642bf2378713e2c2e1de73444a3778e5f0a38be6fee0fe532fe30060282ff"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-win32.whl", hash = "sha256:e46dae94e34b085175f8abb3b0aaa7da40767865ac82c928eeb9e57e1ea8a543"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-win_amd64.whl", hash = "sha256:20f42270d27e1b6a29f54032090b972d97f0a1b0948cc52392041ef7831fee93"},
+    {file = "PyNaCl-1.5.0.tar.gz", hash = "sha256:8ac7448f09ab85811607bdd21ec2464495ac8b7c66d146bf545b0f08fb9220ba"},
+]
+
+[package.dependencies]
+cffi = ">=1.4.1"
+
+[package.extras]
+docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
+tests = ["hypothesis (>=3.27.0)", "pytest (>=3.2.1,!=3.3.0)"]
 
 [[package]]
 name = "pyogrio"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -44,6 +44,7 @@ aiofiles = "^23.2.1"
 docker = "^7"
 toml = "^0.10.2"
 greenlet = "^3.0.3"
+paramiko = "^3.4.0"
 
 [tool.poetry.scripts]
 macrostrat = "macrostrat.cli.cli:main"


### PR DESCRIPTION
First pass at integrating `minio` client into the Macrostrat command line.

We run `minio` in a docker container, pre-seeding aliases to match every configured S3 credential from `tiger-macrostrat-config`. This could be generalized a bit and made easier to work with, but it does allow basic bucket management.

`macrostrat storage mc your-minio-client-command...`

Examples:
- Make a bucket: `macrostrat storage mc mb rockd-backup/rockd-scratch-dev`

For now, you can list users using `macrostrat storage users`. Ideally we'd integrate @brianaydemir's commands for higher-level storage management into this framework.