### PR TITLE
added macrostrat maps staging command

### DIFF
--- a/map-integration/macrostrat/map_integration/__init__.py
+++ b/map-integration/macrostrat/map_integration/__init__.py
@@ -23,6 +23,13 @@ from .migrations import run_migrations
 from .process import cli as _process
 from .process.insert import _delete_map_data
 from .utils import IngestionCLI, MapInfo, table_exists
+from macrostrat.map_integration.utils.file_discovery import find_gis_files
+from macrostrat.map_integration.process.geometry import create_rgeom, create_webgeom
+from macrostrat.map_integration.commands.prepare_fields import _prepare_fields
+from macrostrat.map_integration.utils.map_info import get_map_info
+from macrostrat.map_integration.pipeline import ingest_map
+
+
 
 help_text = f"""Ingest maps into Macrostrat.
 
@@ -234,3 +241,78 @@ def _run_migrations(database: str = None):
 sources.add_command(_run_migrations, name="migrate-schema")
 
 cli.add_typer(sources, name="sources", help="Manage map sources")
+
+#______________________________________________________________________________________________________________________
+
+from macrostrat.map_integration.utils.file_discovery import find_gis_files
+from pathlib import Path
+
+@cli.command(name="staging")
+def staging(
+    slug: str,
+    data_path: str,
+    name: str = Option(None, help="Display name for the map"),
+    scale: str = Option("large", help="Map scale"),
+    object_group_id: int = Option(1, help="Object group ID for ingest_process"),
+    filter: str = Option(None, help="Filter applied to GIS file selection")
+):
+    """
+    Ingest a map, update metadata, prepare fields, and build geometries.
+    """
+    db = get_database()
+    slug = slug.lower().replace(" ", "_")
+    print(f"Ingesting {slug} from {data_path}")
+
+    # Discover files
+    gis_files, excluded_files = find_gis_files(Path(data_path), filter=filter)
+    if not gis_files:
+        raise ValueError(f"No GIS files found in {data_path}")
+
+    print(f"Found {len(gis_files)} GIS file(s)")
+    for path in gis_files:
+        print(f"  ✓ {path}")
+
+    if excluded_files:
+        print(f"Excluded {len(excluded_files)} file(s) due to filter:")
+        for path in excluded_files:
+            print(f"  ⚠️ {path}")
+
+    # Ingest
+    ingest_map(slug, gis_files, if_exists="replace")
+
+    source_id = db.run_query(
+        "SELECT source_id FROM maps.sources_metadata WHERE slug = :slug",
+        dict(slug=slug)
+    ).scalar()
+
+    if source_id is None:
+        raise RuntimeError(f"Could not find source for slug {slug}")
+
+    if name:
+        db.run_sql(
+            "UPDATE maps.sources_metadata SET name = :name WHERE source_id = :source_id",
+            dict(name=name, source_id=source_id)
+        )
+    if scale:
+        db.run_sql(
+            "UPDATE maps.sources_metadata SET scale = :scale WHERE source_id = :source_id",
+            dict(scale=scale, source_id=source_id)
+        ) 
+
+
+    db.run_sql(
+        """
+        INSERT INTO maps_metadata.ingest_process (state, source_id, object_group_id)
+        VALUES ('ingested', :source_id, :object_group_id)
+        """,
+        dict(source_id=source_id, object_group_id=object_group_id)
+    )
+
+    map_info = get_map_info(db, slug)
+    _prepare_fields(map_info)
+    create_rgeom(map_info)
+    create_webgeom(map_info)
+
+    print(f"\nFinished staging setup for {slug}. View map here: https://dev2.macrostrat.org/maps/ingestion/{source_id}/ \n")
+
+

--- a/map-integration/macrostrat/map_integration/utils/file_discovery.py
+++ b/map-integration/macrostrat/map_integration/utils/file_discovery.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+def find_gis_files(directory: Path, filter: str | None = None) -> tuple[list[Path], list[Path]]:
+    """
+    Recursively find GIS files in a directory, applying an optional ingestion filter.
+    Returns a tuple (included_files, excluded_files).
+    """
+    gis_files = (
+        list(directory.rglob("*.gdb")) +
+        list(directory.rglob("*.geojson")) +
+        list(directory.rglob("*.gpkg")) +
+        list(directory.rglob("*.shp"))
+    )
+    gis_data = []
+    excluded_data = []
+
+    for gis_file in gis_files:
+        name = gis_file.name
+        if filter == "polymer":
+            if name.startswith("polymer") and "_bbox" not in name and "_legend" not in name:
+                gis_data.append(gis_file)
+            else:
+                excluded_data.append(gis_file)
+        elif filter == "ta1":
+            if "_bbox" not in name and "_legend" not in name:
+                gis_data.append(gis_file)
+            else:
+                excluded_data.append(gis_file)
+        else:
+            gis_data.append(gis_file)
+
+    return gis_data, excluded_data

--- a/map-integration/macrostrat/map_integration/utils/file_discovery.py
+++ b/map-integration/macrostrat/map_integration/utils/file_discovery.py
@@ -1,15 +1,18 @@
 from pathlib import Path
 
-def find_gis_files(directory: Path, filter: str | None = None) -> tuple[list[Path], list[Path]]:
+
+def find_gis_files(
+    directory: Path, filter: str | None = None
+) -> tuple[list[Path], list[Path]]:
     """
     Recursively find GIS files in a directory, applying an optional ingestion filter.
     Returns a tuple (included_files, excluded_files).
     """
     gis_files = (
-        list(directory.rglob("*.gdb")) +
-        list(directory.rglob("*.geojson")) +
-        list(directory.rglob("*.gpkg")) +
-        list(directory.rglob("*.shp"))
+        list(directory.rglob("*.gdb"))
+        + list(directory.rglob("*.geojson"))
+        + list(directory.rglob("*.gpkg"))
+        + list(directory.rglob("*.shp"))
     )
     gis_data = []
     excluded_data = []
@@ -17,7 +20,11 @@ def find_gis_files(directory: Path, filter: str | None = None) -> tuple[list[Pat
     for gis_file in gis_files:
         name = gis_file.name
         if filter == "polymer":
-            if name.startswith("polymer") and "_bbox" not in name and "_legend" not in name:
+            if (
+                name.startswith("polymer")
+                and "_bbox" not in name
+                and "_legend" not in name
+            ):
                 gis_data.append(gis_file)
             else:
                 excluded_data.append(gis_file)


### PR DESCRIPTION
The `macrostrat maps staging...` command ingests local GIS files, inserts valid fields in the database, and prepares the geometries and fields to be edited in the UI https://dev2.macrostrat.org/maps/ingestion/. This command consolidates the ingest commands and SQL queries below.

From:
```
--In command line: macrostrat maps ingest olho_dagua_do_cruzeiro_brazil /Users/afromandi/Macrostrat/Maps/GSJ_MAP_G050_05009_1961_V01
select * from maps.sources_metadata where slug = 'olho_dagua_do_cruzeiro_brazil';
update maps.sources_metadata set name = 'Olho Dagua do Cruzeiro Brazil' where source_id = 2940;
update maps.sources_metadata set scale = 'large' where source_id = 2940;
INSERT INTO maps_metadata.ingest_process (state, source_id, object_group_id) values ('ingested', 2940, 1); --insert all values here so that it shows up in the UI
select * from maps_metadata.ingest_process where source_id = 2940; --check that the insert populated
--In command line: macrostrat maps prepare-fields olho_dagua_do_cruzeiro_brazil
--In command line: macrostrat maps process rgeom olho_dagua_do_cruzeiro_brazil
--In command line: macrostrat maps process web-geom olho_dagua_do_cruzeiro_brazil
select * from maps.sources order by source_id desc limit 20;
select * from sources.olho_dagua_do_cruzeiro_brazil_polygons;
```

To:
```
macrostrat maps staging lajedinho_brazil /Users/afromandi/Macrostrat/Maps/Brazil/Lajedinho --name "Lajedinho Brazil"

```


The slug, file path, and name are required fields. Otherwise, all other parameters are defaulted or are optional. 

<img width="851" alt="image" src="https://github.com/user-attachments/assets/314b47bf-e417-4be5-b269-87c8b6da893a" />

