### PR TITLE
Improve database testing framework

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="Black">
     <option name="enabledOnReformat" value="true" />

--- a/.idea/mise.xml
+++ b/.idea/mise.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="com.github.l34130.mise.settings.MiseSettings">
+    <option name="executablePath" value="/opt/homebrew/bin/mise" />
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -21,6 +21,7 @@
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/submodules/postgis-tile-utils" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/submodules/storage-admin" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/submodules/topology-manager" vcs="Git" />
   </component>
 </project>

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -23,6 +23,10 @@ def cfg():
         assert cfg_file == settings.config_file
         yield settings
 
+@fixture(scope="session")
+def db():
+    pass
+
 
 def test_cli_help(cfg):
     from macrostrat.cli import main

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -3,17 +3,21 @@
 import importlib
 from pathlib import Path
 
+import docker
+from macrostrat.database import Database
+from macrostrat.dinosaur.upgrade_cluster import database_cluster
+from macrostrat.utils import override_environment
 from pytest import fixture, mark
 from typer.testing import CliRunner
 
-from macrostrat.utils import override_environment
+from macrostrat.core.migrations import _run_migrations_in_database
 
 runner = CliRunner()
 
 __here__ = Path(__file__).parent
 
 
-@fixture
+@fixture(scope="session")
 def cfg():
     cfg_file = __here__ / "macrostrat.test.toml"
     with override_environment(MACROSTRAT_CONFIG=str(cfg_file), NO_COLOR="1"):
@@ -23,9 +27,27 @@ def cfg():
         assert cfg_file == settings.config_file
         yield settings
 
+
 @fixture(scope="session")
-def db():
-    pass
+def db(cfg):
+    # Spin up a docker container with a temporary database
+    image = cfg.get("pg_database_container", "postgres:15")
+
+    client = docker.from_env()
+
+    img_root = cfg.srcroot / "base-images" / "database"
+
+    # Build postgres pgaudit image
+    img_tag = "macrostrat-local-database:latest"
+
+    client.images.build(path=str(img_root), tag=img_tag)
+
+    # Spin up an image with this container
+    port = 54884
+    with database_cluster(client, img_tag, port=port) as container:
+        url = f"postgresql://postgres@localhost:{port}/postgres"
+        db = Database(url)
+        yield db
 
 
 def test_cli_help(cfg):
@@ -50,11 +72,10 @@ def test_cli_no_config():
 
 
 @mark.docker
-def test_database_migrations(cfg):
+def test_database_migrations(db):
     """Test that database migrations can be run."""
-    from macrostrat.core.migrations import _dry_run_migrations
 
-    res = _dry_run_migrations(legacy=False)
+    res = _run_migrations_in_database(db, legacy=False)
 
     assert res.n_migrations > 0
     assert res.n_remaining == 0

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -1,14 +1,10 @@
 """Basic tests that the CLI runs without crashing."""
 
-import importlib
 from pathlib import Path
 
-import docker
-from macrostrat.database import Database
-from macrostrat.dinosaur.upgrade_cluster import database_cluster
 from macrostrat.utils import override_environment
 from psycopg2.sql import Identifier
-from pytest import fixture, mark
+from pytest import mark
 from typer.testing import CliRunner
 
 from macrostrat.core.migrations import _run_migrations_in_database
@@ -16,40 +12,6 @@ from macrostrat.core.migrations import _run_migrations_in_database
 runner = CliRunner()
 
 __here__ = Path(__file__).parent
-
-
-@fixture(scope="session")
-def cfg():
-    cfg_file = __here__ / "macrostrat.test.toml"
-    with override_environment(MACROSTRAT_CONFIG=str(cfg_file), NO_COLOR="1"):
-        importlib.reload(importlib.import_module("macrostrat.core.config"))
-        from macrostrat.core.config import settings
-
-        assert cfg_file == settings.config_file
-        yield settings
-
-
-@fixture(scope="session")
-def db(cfg):
-    # Spin up a docker container with a temporary database
-    image = cfg.get("pg_database_container", "postgres:15")
-
-    client = docker.from_env()
-
-    img_root = cfg.srcroot / "base-images" / "database"
-
-    # Build postgres pgaudit image
-    img_tag = "macrostrat-local-database:latest"
-
-    client.images.build(path=str(img_root), tag=img_tag)
-
-    # Spin up an image with this container
-    port = 54884
-    with database_cluster(client, img_tag, port=port) as container:
-        url = f"postgresql://postgres@localhost:{port}/postgres"
-        db = Database(url)
-        yield db
-
 
 def test_cli_help(cfg):
     from macrostrat.cli import main

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -7,6 +7,7 @@ import docker
 from macrostrat.database import Database
 from macrostrat.dinosaur.upgrade_cluster import database_cluster
 from macrostrat.utils import override_environment
+from psycopg2.sql import Identifier
 from pytest import fixture, mark
 from typer.testing import CliRunner
 
@@ -79,3 +80,14 @@ def test_database_migrations(db):
 
     assert res.n_migrations > 0
     assert res.n_remaining == 0
+
+
+def test_maps_tables_exist(db):
+    """Test that the tables exist in the database."""
+
+    for table in ["polygons", "lines", "points"]:
+        res = db.run_query(
+            "SELECT * FROM {table}", dict(table=Identifier("maps", table))
+        ).all()
+
+        assert len(res) == 0

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,48 @@
+"""Basic tests that the CLI runs without crashing."""
+
+import importlib
+from pathlib import Path
+
+import docker
+from macrostrat.database import Database
+from macrostrat.dinosaur.upgrade_cluster import database_cluster
+from macrostrat.utils import override_environment
+from pytest import fixture
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+__here__ = Path(__file__).parent
+
+
+@fixture(scope="session")
+def cfg():
+    cfg_file = __here__ /"cli"/"tests"/ "macrostrat.test.toml"
+    with override_environment(MACROSTRAT_CONFIG=str(cfg_file), NO_COLOR="1"):
+        importlib.reload(importlib.import_module("macrostrat.core.config"))
+        from macrostrat.core.config import settings
+
+        assert cfg_file == settings.config_file
+        yield settings
+
+
+@fixture(scope="session")
+def db(cfg):
+    # Spin up a docker container with a temporary database
+    image = cfg.get("pg_database_container", "postgres:15")
+
+    client = docker.from_env()
+
+    img_root = cfg.srcroot / "base-images" / "database"
+
+    # Build postgres pgaudit image
+    img_tag = "macrostrat-local-database:latest"
+
+    client.images.build(path=str(img_root), tag=img_tag)
+
+    # Spin up an image with this container
+    port = 54884
+    with database_cluster(client, img_tag, port=port) as container:
+        url = f"postgresql://postgres@localhost:{port}/postgres"
+        db = Database(url)
+        yield db

--- a/map-integration/tests/test_map_staging.py
+++ b/map-integration/tests/test_map_staging.py
@@ -1,0 +1,23 @@
+from psycopg2.sql import Identifier
+
+
+def test_maps_tables_exist(db):
+    """Test that the tables exist in the database."""
+
+    for table in ["polygons", "lines", "points"]:
+        res = db.run_query(
+            "SELECT * FROM {table}", dict(table=Identifier("maps", table))
+        ).all()
+
+        assert len(res) == 0
+
+
+def test_get_database(db):
+    from macrostrat.core.database import db_ctx
+
+    db_ctx.set(db)
+    from macrostrat.map_integration.database import get_database
+
+    db1 = get_database()
+
+    assert db1 is db


### PR DESCRIPTION
- Add a fixture that sets up an empty database
- Move database config to top level so it is accessible from multiple parts of app
- Create skeletal tests that database tables exist in `macrostrat.map_integration` module

This will help the `make test` command become more powerful in the future.