### PR TITLE
Model feedback schema

### DIFF
--- a/cli/macrostrat/cli/database/rockd/model-feedback-schema.sql
+++ b/cli/macrostrat/cli/database/rockd/model-feedback-schema.sql
@@ -11,7 +11,9 @@ CREATE TABLE IF NOT EXISTS public.model_feedback (
 );
 
 ALTER TABLE public.checkins
-    ADD model_run_id integer;
+    ADD COLUMN model_run_id integer;
+
+ALTER TABLE public.checkins
     ADD CONSTRAINT fk_model_run
         FOREIGN KEY (model_run_id)
         REFERENCES public.model_feedback(id)


### PR DESCRIPTION
Lays out schema for model_feedback table

Works toward completing UW-Macrostrat/rockd/issues/363

The idea is that the id in this table references the model_run_id in the checkins table