### PR TITLE
Implement and Test RLS Functionality for User Locations Feature

### DIFF
--- a/cli/macrostrat/cli/database/migrations/user_features/postgrest_user_locations.sql
+++ b/cli/macrostrat/cli/database/migrations/user_features/postgrest_user_locations.sql
@@ -1,0 +1,45 @@
+--This query adds postgrest via views created.
+--allows grant access to users
+--adds policies to implement RLS for designated users.
+GRANT SELECT, INSERT, UPDATE, DELETE ON
+  user_features.user_locations,
+  user_features.location_tags_intersect
+  TO web_user;
+GRANT SELECT ON user_features.location_tags TO web_user;
+GRANT USAGE, SELECT ON SEQUENCE user_features.user_locations_id_seq TO web_user;
+
+--expose tables as views so postgrest routes are created.
+--CRUD ops work
+CREATE OR REPLACE VIEW macrostrat_api.user_locations  AS
+  SELECT * FROM user_features.user_locations;
+--READ ONLY
+CREATE OR REPLACE VIEW macrostrat_api.location_tags  AS
+  SELECT * FROM user_features.location_tags;
+--CRUD ops work
+CREATE OR REPLACE VIEW macrostrat_api.location_tags_intersect  AS
+  SELECT * FROM user_features.location_tags_intersect;
+--grant postgrest api access for the users below
+GRANT SELECT, INSERT, UPDATE, DELETE ON macrostrat_api.user_locations TO web_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON macrostrat_api.location_tags_intersect TO web_user;
+--read only access to predetermined tag list
+GRANT   SELECT ON macrostrat_api.location_tags TO web_user;
+--ask PostgREST to pick up the view changes
+NOTIFY pgrst, 'reload schema';
+
+
+
+
+--create the postgrest POLICIES for the location table
+ALTER TABLE user_features.user_locations ENABLE ROW LEVEL SECURITY;
+CREATE POLICY pl_user_locations_all
+ON user_features.user_locations
+USING      (user_id = current_app_user_id())
+WITH CHECK (user_id = current_app_user_id());
+
+--create the postgrest POLICIES for the location_tags_intersect table
+ALTER TABLE user_features.location_tags_intersect ENABLE ROW LEVEL SECURITY;
+CREATE POLICY pl_tag_bridge_all
+ON user_features.location_tags_intersect
+USING      (user_id = current_app_user_id())
+WITH CHECK (user_id = current_app_user_id());
+

--- a/cli/macrostrat/cli/database/migrations/user_features/user_locations_schema.sql
+++ b/cli/macrostrat/cli/database/migrations/user_features/user_locations_schema.sql
@@ -18,7 +18,7 @@ create table IF NOT EXISTS user_features.user_locations
     updated_at      timestamp default now() not null
 );
 
-
+--add predefined list of tags for users to use
 create table IF NOT EXISTS user_features.location_tags
 (
     id          serial PRIMARY KEY,
@@ -26,6 +26,20 @@ create table IF NOT EXISTS user_features.location_tags
     description text,
     color       varchar(30)
 );
+
+INSERT INTO user_features.location_tags (name, description, color)
+VALUES
+  ('Basalt Outcrop',      'Exposure of dark, fine‑grained basaltic lava',          '#4B4E6D'),
+  ('Fossil Locality',     'Site where macro‑ or microfossils have been collected', '#C19A6B'),
+  ('Fault Trace',         'Mapped surface expression of a fault plane',            '#FF6F61'),
+  ('Glacial Erratic',     'Large exotic boulder deposited by glacial ice',         '#3DA5D9'),
+  ('Mineral Prospect',    'Area under evaluation for economic mineralization',     '#FFD166'),
+  ('Stratotype Section',  'Formally designated reference stratigraphic section',   '#6D8B74'),
+  ('Core Sample Site',    'Location where drill‑core was extracted',               '#8E7DBE'),
+  ('Hydrothermal Vent',   'Vent or fissure of hydrothermal fluids (active/pale)',  '#E9724C'),
+  ('Paleosol Horizon',    'Profile of an ancient soil preserved in the rock record','#A67C52'),
+  ('Dike Intrusion',      'Tabular igneous body cutting host strata',              '#FFB3BA');
+
 
 --intersection table for ids joins with the location_tags table
 --remove category and add NULL user_ids
@@ -40,32 +54,6 @@ create table IF NOT EXISTS user_features.location_tags_intersect (
 alter table user_features.user_locations owner to "macrostrat";
 alter table user_features.location_tags owner to "macrostrat";
 alter table user_features.location_tags_intersect owner to "macrostrat";
-
-grant delete, insert, select, update on user_features.user_locations to web_anon;
-grant delete, insert, select, update on user_features.location_tags to web_anon;
-GRANT USAGE, SELECT ON SEQUENCE user_features.user_locations_id_seq TO web_anon;
-
-grant delete, insert, select, update on user_features.user_locations to web_user;
-grant delete, insert, select, update on user_features.location_tags to web_user;
-GRANT USAGE, SELECT ON SEQUENCE user_features.user_locations_id_seq TO web_anon;
-
-
-CREATE OR REPLACE VIEW macrostrat_api.user_locations AS
-SELECT *
-FROM user_features.user_locations;
-
-
-CREATE OR REPLACE VIEW macrostrat_api.location_tags AS
-SELECT *
-FROM user_features.location_tags;
-
---this will change from web_anon to an authorized user once that workflow has been implemented.
---web_anon is used for testing only right now.
-GRANT SELECT, INSERT, UPDATE, DELETE ON macrostrat_api.user_locations TO web_anon;
-GRANT SELECT, INSERT, UPDATE, DELETE ON macrostrat_api.location_tags TO web_anon;
-
-
-NOTIFY pgrst, 'reload schema';
 
 
 

--- a/cli/macrostrat/cli/subsystems/macrostrat_api/roles.sql
+++ b/cli/macrostrat/cli/subsystems/macrostrat_api/roles.sql
@@ -10,6 +10,8 @@ CREATE ROLE web_user NOLOGIN;
 -- For a Macrostrat administrator
 CREATE ROLE web_admin NOLOGIN;
 
+CREATE ROLE web_anon NOLOGIN;
+
 -- Postgrest is our 'authenticator' role
 -- We need to allow it to switch to the web roles
 GRANT web_anon TO postgrest;
@@ -24,4 +26,15 @@ GRANT web_anon TO web_user;
 
 -- Grant web_user capabilities to web_admin
 GRANT web_user TO web_admin;
+
+
+--POSTGREST helper functions for RLS security
+--Pull `"user_id"` out of the JWT that PostgREST stores in request.jwt.claims
+CREATE OR REPLACE FUNCTION current_app_user_id()
+RETURNS int
+STABLE
+LANGUAGE sql
+AS $$
+  SELECT (current_setting('request.jwt.claims', true)::json ->> 'user_id')::int
+$$;
 

--- a/services/api-v3/api/routes/security.py
+++ b/services/api-v3/api/routes/security.py
@@ -281,7 +281,7 @@ async def redirect_callback(code: str, state: Optional[str] = None):
                 )
 
             user_data = await user_response.json()
-
+            #need to look up the user_id and return it in the jwt
             user = await get_user(user_data["sub"])
 
             if user is None:
@@ -306,12 +306,13 @@ async def redirect_callback(code: str, state: Optional[str] = None):
             if "admin" in names:
                 role = "web_admin"
 
+            #validate jwt https://dev.macrostrat.org/dev/me
             access_token = create_access_token(
                 data={
                     "sub": user.sub,
                     "role": role,  # For PostgREST
-                    "groups": [group.id for group in user.groups],
-                    "group_names": names,
+                    #ensure user_id is correctly being returned
+                    "user_id": user.id,
                 }
             )
 

--- a/services/api-v3/api/routes/security.py
+++ b/services/api-v3/api/routes/security.py
@@ -281,7 +281,7 @@ async def redirect_callback(code: str, state: Optional[str] = None):
                 )
 
             user_data = await user_response.json()
-            #need to look up the user_id and return it in the jwt
+            # need to look up the user_id and return it in the jwt
             user = await get_user(user_data["sub"])
 
             if user is None:
@@ -306,12 +306,12 @@ async def redirect_callback(code: str, state: Optional[str] = None):
             if "admin" in names:
                 role = "web_admin"
 
-            #validate jwt https://dev.macrostrat.org/dev/me
+            # validate jwt https://dev.macrostrat.org/dev/me
             access_token = create_access_token(
                 data={
                     "sub": user.sub,
                     "role": role,  # For PostgREST
-                    #ensure user_id is correctly being returned
+                    # ensure user_id is correctly being returned
                     "user_id": user.id,
                 }
             )


### PR DESCRIPTION
### Key Updates:
- Defined `web_user`, `web_admin`, and `web_anon` roles in `/subsystems/macrostrat_api/roles.sql`

- Added a helper function for PostgREST to extract `user_id` from the JWT (request.jwt.claims).

- Granted role-specific privileges to `web_user` at the table level.

- Created PostgREST-exposed views in the `macrostrat_api` schema.

- Granted `web_user` appropriate CRUD permissions on selected views/tables.

- Reloaded PostgREST schema to apply updated views and permissions.

- Enabled RLS on applicable tables (`user_locations`, `location_tags_intersect`) and implemented `USING / WITH CHECK` policies based on the authenticated `user_id`.
---
Next steps:
- Test all `user_locations` endpoints via PostgREST to validate RLS enforcement.
