### PR TITLE
Measurements tile route

### DIFF
--- a/services/tileserver/macrostrat/tileserver/__init__.py
+++ b/services/tileserver/macrostrat/tileserver/__init__.py
@@ -200,6 +200,10 @@ from .fossils import router as fossils_router
 
 app.include_router(fossils_router, tags=["PBDB"], prefix="/pbdb")
 
+from .measurements import router as measurements_router
+
+app.include_router(measurements_router, tags=["Measurements"], prefix="/measurements")
+
 from .integrations import router as integrations_router
 
 app.include_router(integrations_router, tags=["Integrations"], prefix="/integrations")

--- a/services/tileserver/macrostrat/tileserver/measurements/__init__.py
+++ b/services/tileserver/macrostrat/tileserver/measurements/__init__.py
@@ -1,0 +1,117 @@
+from pathlib import Path
+
+from buildpg import render
+from fastapi import APIRouter, Request, Response
+from timvt.resources.enums import MimeTypes
+
+router = APIRouter()
+
+__here__ = Path(__file__).parent
+
+
+@router.get("/tile/{z}/{x}/{y}")
+async def tile_query(
+    request: Request,
+    z: int,
+    x: int,
+    y: int,
+):
+    """Get a tile from the tileserver."""
+    pool = request.app.state.pool
+
+    if "type" in request.query_params:
+        type_val = request.query_params["type"]
+
+    if "cluster" in request.query_params:
+        cluster_val = request.query_params["cluster"]
+        cluster = cluster_val.lower() not in ("false", "0", "no")
+
+    else:
+        cluster = True
+
+    where = ""
+
+    clusterSQL = """
+        ,
+
+        mvt_features AS (
+            SELECT id,
+                    ST_SnapToGrid(geom, 256, 256) AS cluster_geom,
+                    geom
+            FROM points
+        ),
+        grouped_features AS (
+            SELECT
+                tile_utils.cluster_expansion_zoom(ST_Collect(geom), :z) AS expansion_zoom,
+                count(*) AS n,
+                st_centroid(ST_Collect(geom)) AS geom,
+                CASE
+                WHEN count(*) < 2 THEN string_agg(f.id::text, ',')
+                ELSE null
+                END AS id
+            FROM mvt_features f
+            GROUP BY cluster_geom
+        )
+        SELECT ST_AsMVT(row) AS mvt
+        FROM (SELECT * FROM grouped_features) AS row;
+    """
+
+    unclusteredSQL = """
+        SELECT ST_AsMVT(
+                points.*,
+                'default',
+                4096,
+                'geom'
+            ) AS mvt
+            FROM points
+    """
+
+    if cluster:
+        ending = clusterSQL
+    else:
+        ending = unclusteredSQL
+
+    query = f"""
+        WITH
+            tile AS (
+            SELECT ST_TileEnvelope({z}, {x}, {y}) AS envelope,
+                    tile_layers.geographic_envelope({x}, {y}, {z}, 0.01) AS envelope_4326
+            ),
+            points AS (
+            SELECT
+                id,
+                sample_name,
+                sample_lith,
+                sample_geo_unit,
+                tile_layers.tile_geom(
+                    ST_Intersection(geometry, envelope_4326),
+                    envelope
+                ) AS geom
+            FROM macrostrat.measuremeta, tile
+            WHERE
+                lat IS NOT NULL AND lng IS NOT NULL
+                AND ST_Intersects(
+                ST_SetSRID(ST_MakePoint(lng, lat), 4326),
+                envelope_4326
+                )
+                {where}
+            )
+
+            {ending}
+    """
+
+
+
+    params = {
+        "z": z,
+        "x": x,
+        "y": y,
+    }
+
+    q, p = render(query, **params)
+    q = q.replace("textarray", "text[]")
+
+    async with pool.acquire() as con:
+        data = await con.fetchval(q, *p)
+
+    return Response(data, media_type=MimeTypes.pbf.value)

--- a/services/tileserver/macrostrat/tileserver/measurements/__init__.py
+++ b/services/tileserver/macrostrat/tileserver/measurements/__init__.py
@@ -29,9 +29,10 @@ async def tile_query(
 
 
     if "type" in request.query_params:
-        type_val = request.query_params["type"]
-        where += " AND type = :type_val"
-        params["type_val"] = type_val
+        type_vals = request.query_params["type"].split(",")
+        type_vals = [v.strip() for v in type_vals if v.strip()]
+        where += " AND type = ANY(:type_vals)"
+        params["type_vals"] = type_vals
 
     if "cluster" in request.query_params:
         cluster_val = request.query_params["cluster"]

--- a/services/tileserver/macrostrat/tileserver/measurements/__init__.py
+++ b/services/tileserver/macrostrat/tileserver/measurements/__init__.py
@@ -27,7 +27,6 @@ async def tile_query(
         "y": y,
     }
 
-
     if "type" in request.query_params:
         type_vals = request.query_params["type"].split(",")
         type_vals = [v.strip() for v in type_vals if v.strip()]
@@ -40,7 +39,6 @@ async def tile_query(
 
     else:
         cluster = True
-
 
     clusterSQL = """
         ,


### PR DESCRIPTION
Creates measurements tile route at `/measurements/tile` 

Takes params:
- `type` as a comma separated list to filter by (union)
- `cluster` to turn on and off clustering