### PR TITLE
Bulk stratigraphic name matching

### DIFF
--- a/local-root/Makefile
+++ b/local-root/Makefile
@@ -2,6 +2,7 @@ all:
 	# Install all dependencies
 	# Install all optional dependency groups (dev, gis, etc)
 	uv sync
+	uv add "psycopg[binary]"
 
 start-database:
 	# Install GIS dependencies

--- a/local-root/Makefile
+++ b/local-root/Makefile
@@ -12,8 +12,7 @@ start-gateway:
 	macrostrat compose up -d gateway
 
 build-restart:
-	macrostrat compose build api_v3
-	macrostrat compose up -d --force-recreate api_v3
+	macrostrat compose up -d --build --force-recreate
 
 start-services:
 	macrostrat compose up -d gateway postgrest api_v2 api_v3 tileserver_core tileserver_legacy tileserver_cache

--- a/py-modules/match-utils/macrostrat/match_utils/__init__.py
+++ b/py-modules/match-utils/macrostrat/match_utils/__init__.py
@@ -75,8 +75,12 @@ MATCH_STRAT_NAMES_INFO = {
             "output_formats": ["json"],
             "methods": {
                 "GET": "Single query via URL parameters.",
-                "POST": "Batch query — accepts a JSON array of up to 100 query objects. "
-                "MatchOptions (all, basis) are passed as query parameters.",
+                "POST": "Batch query. Accepts either 1. a JSON array of up to 100 full "
+                "query objects, each with its own location; MatchOptions (all, basis) are "
+                "passed as query parameters; or 2. a JSON object with a single shared "
+                "location/options and a 'strat_names' list of (id, strat_name) pairs "
+                "(e.g. [[932043, 'Navajo'], [74382, 'Navajo Sandstone']]). Each supplied "
+                "id is echoed back as 'id' on the corresponding result for correlation.",
             },
             "examples": [
                 "/dev/match/strat-names?strat_name=Navajo Sandstone&lat=35.951&lng=-109.905",

--- a/services/api-v3/api/match/__init__.py
+++ b/services/api-v3/api/match/__init__.py
@@ -70,40 +70,13 @@ class AbsoluteAgeConstraint(BaseModel):
     t_age: float = Field(None, description="Late/upper age constraint in Ma")
 
 
-class MatchQuery(BaseModel):
-    strat_name: str | None = Field(
-        None,
-        description="Text containing a stratigraphic name to match.",
-        examples=[
-            "Navajo Sandstone",
-            "Halgaito Member",
-            "Coconino",
-            "Dakota Formation",
-            "Matchless Amphibolite",
-            "broke neck pluton; Escapement Bay Fm",
-            "Morrison Fm",
-            "Kayenta Formation; Davis Branch Mbr; Wingate Sandstone",
-        ],
-    )
-    concept_name: str | None = Field(
-        None,
-        description="Text containing a concept name to match.",
-        examples=[
-            "Navajo",
-            "Dakota",
-            "Morrison",
-            "Kayenta",
-        ],
-    )
-    strat_name_id: int | None = Field(
-        None, description="A Macrostrat stratigraphic name ID to match directly."
-    )
-    concept_id: int | None = Field(
-        None, description="A Macrostrat concept ID to match directly."
-    )
-    identifier: str | int | None = Field(
-        None, description="An optional identifier to associate with this query."
-    )
+class MatchContext(BaseModel):
+    """Shared location, age, and priority fields used to constrain a match.
+
+    Factored out of MatchQuery so that both single queries and shared-location
+    batch queries (MatchBatchQuery) can reuse the same location/age handling.
+    """
+
     lat: float | None = None
     lng: float | None = None
     col_id: int | None = Field(
@@ -135,20 +108,6 @@ class MatchQuery(BaseModel):
             "matches prioritized before broader concept, rank-down, rank-up, or synonym matches."
         ),
     )
-
-    @model_validator(mode="after")
-    def validate_match_input(self):
-        """Ensure that either strat_name or strat_name_id is provided."""
-        if (
-            self.strat_name is None
-            and self.strat_name_id is None
-            and self.concept_id is None
-            and self.concept_name is None
-        ):
-            raise ValueError(
-                "Either strat_name/concept_name or strat_name_id/concept_id must be provided."
-            )
-        return self
 
     @model_validator(mode="after")
     def validate_position_info(self):
@@ -184,6 +143,56 @@ class MatchQuery(BaseModel):
         return AbsoluteAgeConstraint(b_age=b_age, t_age=t_age)
 
 
+class MatchQuery(MatchContext):
+    strat_name: str | None = Field(
+        None,
+        description="Text containing a stratigraphic name to match.",
+        examples=[
+            "Navajo Sandstone",
+            "Halgaito Member",
+            "Coconino",
+            "Dakota Formation",
+            "Matchless Amphibolite",
+            "broke neck pluton; Escapement Bay Fm",
+            "Morrison Fm",
+            "Kayenta Formation; Davis Branch Mbr; Wingate Sandstone",
+        ],
+    )
+    concept_name: str | None = Field(
+        None,
+        description="Text containing a concept name to match.",
+        examples=[
+            "Navajo",
+            "Dakota",
+            "Morrison",
+            "Kayenta",
+        ],
+    )
+    strat_name_id: int | None = Field(
+        None, description="A Macrostrat stratigraphic name ID to match directly."
+    )
+    concept_id: int | None = Field(
+        None, description="A Macrostrat concept ID to match directly."
+    )
+    identifier: str | int | None = Field(
+        None, description="An optional identifier to associate with this query."
+    )
+
+    @model_validator(mode="after")
+    def validate_match_input(self):
+        """Ensure that either strat_name or strat_name_id is provided."""
+        if (
+            self.strat_name is None
+            and self.strat_name_id is None
+            and self.concept_id is None
+            and self.concept_name is None
+        ):
+            raise ValueError(
+                "Either strat_name/concept_name or strat_name_id/concept_id must be provided."
+            )
+        return self
+
+
 class MatchMessageType(enum.Enum):
     Info = "info"
     Warning = "warning"
@@ -213,6 +222,11 @@ class MatchMessage(BaseModel):
 
 
 class MatchData(BaseModel):
+    id: str | int | None = Field(
+        None,
+        description="The identifier supplied with the input query, echoed back so "
+        "batch results can be correlated to their input.",
+    )
     unit_matches: list[MatchResult]
     messages: list[MatchMessage]
 
@@ -239,6 +253,68 @@ class MatchOptions(BaseModel):
 
 class MatchSingleQueryParams(MatchQuery, MatchOptions):
     pass
+
+
+class StratNameItem(BaseModel):
+    """A single (id, strat_name) pair in a shared-location batch query.
+
+    Accepts either a 2-element ``[id, strat_name]`` array (the JSON rendering of
+    an ``(id, strat_name)`` tuple) or an explicit ``{"id": ..., "strat_name": ...}``
+    object.
+    """
+
+    id: str | int = Field(
+        ..., description="User-supplied identifier, returned back in the result."
+    )
+    strat_name: str = Field(..., description="Stratigraphic name text to match.")
+
+    @model_validator(mode="before")
+    @classmethod
+    def coerce_pair(cls, data):
+        if isinstance(data, (list, tuple)):
+            if len(data) != 2:
+                raise ValueError(
+                    "Each strat_names entry must be an (id, strat_name) pair."
+                )
+            return {"id": data[0], "strat_name": data[1]}
+        return data
+
+
+class MatchBatchQuery(MatchContext, MatchOptions):
+    """A shared-location batch query.
+
+    A single location (``lat``/``lng`` or ``col_id``), age constraint, priority,
+    and set of match options are applied to every ``(id, strat_name)`` pair in
+    ``strat_names``. Each pair is expanded into an individual MatchQuery, and the
+    supplied ``id`` is echoed back on the corresponding result.
+    """
+
+    strat_names: list[StratNameItem] = Field(
+        ...,
+        description="List of (id, strat_name) pairs to match against the shared location.",
+        examples=[[[932043, "Navajo"], [74382, "Navajo Sandstone"], [382950, "Morrison"]]],
+    )
+
+    def to_queries(self) -> list["MatchQuery"]:
+        """Expand each (id, strat_name) pair into a MatchQuery sharing this context."""
+        shared = self.model_dump(
+            include={
+                "lat",
+                "lng",
+                "col_id",
+                "project_id",
+                "b_interval",
+                "t_interval",
+                "interval",
+                "b_age",
+                "t_age",
+                "priority",
+            }
+        )
+        return [
+            MatchQuery(strat_name=item.strat_name, identifier=item.id, **shared)
+            for item in self.strat_names
+        ]
 
 
 NameBasis = Literal["exact", "concept", "rank-down", "rank-up", "synonym"]
@@ -380,14 +456,32 @@ def match_units(
 
 @router.post("/strat-names")
 def match_units_multi(
-    body: list[MatchQuery],
+    body: list[MatchQuery] | MatchBatchQuery,
     query: Annotated[MatchOptions, Query()],
 ):
     """
     Match multiple stratigraphic name queries in a single request.
+
+    Two body shapes are accepted:
+
+    - A JSON **array** of full query objects, each carrying its own location and
+      options. MatchOptions (``all``, ``basis``) are read from query parameters.
+    - A JSON **object** (MatchBatchQuery) with a single shared location/options and
+      a ``strat_names`` list of ``(id, strat_name)`` pairs. Options are read from
+      the body, and each supplied ``id`` is echoed back on its result.
+
     :return: MatchAPIResponse
     """
-    opts = MatchOptions(**query.model_dump())
+    if isinstance(body, MatchBatchQuery):
+        # Shared-location batch: options come from the body, queries are expanded
+        # from the (id, strat_name) pairs.
+        opts = MatchOptions(all=body.all, basis=body.basis)
+        queries = body.to_queries()
+    else:
+        # Array of full query objects: options come from query parameters.
+        opts = MatchOptions(**query.model_dump())
+        queries = body
+
     if opts.basis is None:
         opts.basis = set(get_match_types(None))
 
@@ -396,10 +490,10 @@ def match_units_multi(
 
     all_results: list[MatchData] = []
 
-    if len(body) > 100:
+    if len(queries) > 100:
         raise ValueError("Maximum of 100 queries allowed per request.")
 
-    for params in body:
+    for params in queries:
         match_data = build_match_data(db, params)
         if match_data is not None:
             all_results.append(match_data)
@@ -413,6 +507,7 @@ def generate_response(
     if not opts.all:
         results = [
             MatchData(
+                id=result.id,
                 unit_matches=[m for m in result.unit_matches if m.priority == 0.0],
                 messages=result.messages,
             )
@@ -504,6 +599,7 @@ def build_match_data(db, params):
     if params.strat_name is not None and params.concept_name is not None:
         # Return an error result
         return MatchData(
+            id=params.identifier,
             unit_matches=[],
             messages=[
                 MatchMessage(
@@ -517,6 +613,7 @@ def build_match_data(db, params):
     if age_constraint.b_age < age_constraint.t_age:
         # Return an error result
         return MatchData(
+            id=params.identifier,
             unit_matches=[],
             messages=[
                 MatchMessage(
@@ -590,4 +687,4 @@ def build_match_data(db, params):
             )
         )
     results = assign_priorities(results, params.priority)
-    return MatchData(unit_matches=results, messages=messages)
+    return MatchData(id=params.identifier, unit_matches=results, messages=messages)

--- a/services/api-v3/api/match/__init__.py
+++ b/services/api-v3/api/match/__init__.py
@@ -292,7 +292,9 @@ class MatchBatchQuery(MatchContext, MatchOptions):
     strat_names: list[StratNameItem] = Field(
         ...,
         description="List of (id, strat_name) pairs to match against the shared location.",
-        examples=[[[932043, "Navajo"], [74382, "Navajo Sandstone"], [382950, "Morrison"]]],
+        examples=[
+            [[932043, "Navajo"], [74382, "Navajo Sandstone"], [382950, "Morrison"]]
+        ],
     )
 
     def to_queries(self) -> list["MatchQuery"]:

--- a/services/api-v3/api/match/test_match_route.py
+++ b/services/api-v3/api/match/test_match_route.py
@@ -150,6 +150,67 @@ def test_multi_match_units(client):
         assert best_match["strat_name_id"] == case.strat_name_id
 
 
+def test_batch_match_units_shared_location(client):
+    """POST a shared location plus a list of (id, strat_name) pairs.
+
+    Each input id should be echoed back on its result so callers can correlate,
+    and results should stay one-per-input in order.
+    """
+    pairs = [(1000 + i, c.match_text) for i, c in enumerate(cases)]
+    response = client.post(
+        "/strat-names",
+        json={
+            "strat_names": pairs,
+            "lat": cases[0].xy[1],
+            "lng": cases[0].xy[0],
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "results" in data
+
+    results = data["results"]
+    assert len(results) == len(cases)
+
+    for res, case, (pair_id, _name) in zip(results, cases, pairs):
+        # The supplied id is echoed back for correlation.
+        assert res["id"] == pair_id
+
+        matches = res["unit_matches"]
+        assert_valid_unit_matches(matches)
+
+        # Default all=false returns exactly one best-priority match per input.
+        assert len(matches) == 1
+        best_match = matches[0]
+        assert best_match["priority"] == 0.0
+        assert best_match["unit_id"] == case.unit_id
+        assert best_match["strat_name_id"] == case.strat_name_id
+
+
+def test_batch_match_units_col_id_and_all_in_body(client):
+    """Batch body accepts col_id instead of lat/lng and reads `all` from the body."""
+    response = client.post(
+        "/strat-names",
+        json={
+            "strat_names": [[42, "Mancos"]],
+            "col_id": 490,
+            "all": True,
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    results = data["results"]
+    assert len(results) == 1
+    assert results[0]["id"] == 42
+
+    matches = results[0]["unit_matches"]
+    assert_valid_unit_matches(matches)
+    # all=true (read from the body) should return more than the single best match.
+    priorities = [m["priority"] for m in matches]
+    assert priorities == sorted(priorities)
+    assert len(matches) > 1
+
+
 def test_match_units_ambiguous_column(client):
     response = client.get(
         "/strat-names",


### PR DESCRIPTION
## Bulk stratigraphic name matching

`POST /match/strat-names` now supports a shared location, age, priority request format.

Previously, callers could batch match names by sending an array of full MatchQuery objects. That still works. Each item had to include its own location, such as `lat/lng` or `col_id`.

This update adds another request body format: users can now send one shared location with a list of stratigraphic names (and age and priority). This is much more efficient when matching many names against the same point or column.

## What changed

* The existing array request format is unchanged.
* A new object request format is supported for shared-location batch matching.
* Each input name can include an `id`, which is returned with the matching result.
* `all: true` can be included in the object body to return all ranked matches.
* By default, `all: false` returns only the best match for each name.
* Each request must provide either `lat` and `lng`, or `col_id`.
* The batch limit is 100 stratigraphic names.

## Endpoint

```http
POST https://macrostrat.local/api/v3/dev/match/strat-names
Content-Type: application/json
```

## Option 1: Existing array body

Use this when each query may have its own location or options.

URL:

```http
POST https://macrostrat.local/api/v3/dev/match/strat-names?all=true
```

Body:

```json
[
  {
    "strat_name": "Navajo",
    "lat": 35.951,
    "lng": -109.905,
    "identifier": "sample-001"
  },
  {
    "strat_name": "Halgaito Member",
    "lat": 35.951,
    "lng": -109.905,
    "identifier": "sample-002"
  },
  {
    "strat_name": "Mancos",
    "col_id": 490
  }
]
```

## Option 2: New shared-location object body

Use this when all names should be matched against the same location.

URL:

```http
POST https://macrostrat.local/api/v3/dev/match/strat-names
```

Body:

```json
{
  "strat_names": [
    [932043, "Navajo"],
    [74382, "Navajo Sandstone"],
    [382950, "Morrison"]
  ],
  "lat": 39.41922,
  "lng": -111.950684,
  "all": true
}
```


## Additional age and priority filters

URL:

```http
POST https://macrostrat.local/api/v3/dev/match/strat-names
```

Body:

```json
{
  "strat_names": [
    {
      "id": "abc",
      "strat_name": "Jelm Formation"
    },
    {
      "id": "def",
      "strat_name": "Morrison"
    }
  ],
  "lat": 40.9,
  "lng": -105.6,
  "interval": "Triassic",
  "priority": "strat_name",
  "all": true
}
```

## Response

Each result includes the input `id` so callers can match matches back to their original inputs with a custom `id`.

Example response shape:

```json
{
  "version": "0.0.1",
  "date_accessed": "2026-06-29T...",
  "results": [
    {
      "id": 932043,
      "unit_matches": [
        {
          "unit_id": 14623,
          "strat_name": "Navajo Sandstone",
          "priority": 0.0,
          "name_basis": "exact",
          "spatial_basis": "containing column"
        }
      ],
      "messages": []
    }
  ],
  "name_bases": ["exact", "concept"],
  "messages": null
}
```

