### PR TITLE
Match params fixes

### DIFF
--- a/local-root/Makefile
+++ b/local-root/Makefile
@@ -2,6 +2,7 @@ all:
 	# Install all dependencies
 	# Install all optional dependency groups (dev, gis, etc)
 	uv sync
+	uv add "psycopg[binary]"
 
 start-database:
 	# Install GIS dependencies

--- a/local-root/Makefile
+++ b/local-root/Makefile
@@ -12,8 +12,7 @@ start-gateway:
 	macrostrat compose up -d gateway
 
 build-restart:
-	macrostrat compose build api_v3
-	macrostrat compose up -d --force-recreate api_v3
+	macrostrat compose up -d --build --force-recreate
 
 start-services:
 	macrostrat compose up -d gateway postgrest api_v2 api_v3 tileserver_core tileserver_legacy tileserver_cache

--- a/py-modules/match-utils/macrostrat/match_utils/__init__.py
+++ b/py-modules/match-utils/macrostrat/match_utils/__init__.py
@@ -75,8 +75,12 @@ MATCH_STRAT_NAMES_INFO = {
             "output_formats": ["json"],
             "methods": {
                 "GET": "Single query via URL parameters.",
-                "POST": "Batch query — accepts a JSON array of up to 100 query objects. "
-                "MatchOptions (all, basis) are passed as query parameters.",
+                "POST": "Batch query. Accepts either 1. a JSON array of up to 100 full "
+                "query objects, each with its own location; MatchOptions (all, basis) are "
+                "passed as query parameters; or 2. a JSON object with a single shared "
+                "location/options and a 'strat_names' list of (id, strat_name) pairs "
+                "(e.g. [[932043, 'Navajo'], [74382, 'Navajo Sandstone']]). Each supplied "
+                "id is echoed back as 'id' on the corresponding result for correlation.",
             },
             "examples": [
                 "/dev/match/strat-names?strat_name=Navajo Sandstone&lat=35.951&lng=-109.905",

--- a/py-modules/match-utils/macrostrat/match_utils/__init__.py
+++ b/py-modules/match-utils/macrostrat/match_utils/__init__.py
@@ -68,15 +68,18 @@ MATCH_STRAT_NAMES_INFO = {
                 "collection ID). Passed through to the response for correlation.",
                 "all": "boolean, if true return all matches ordered by priority. "
                 "If false (default), return only the highest priority match (priority=0.0).",
-                "basis": "string, matching strategies to use. One or more of: "
-                "column-units | adjacent-cols | concepts | synonyms | footprint-index. "
-                "Default: all strategies enabled.",
+                "name_basis": "string, filter results to only those with this name_basis. "
+                "One of: exact | concept | rank-down | rank-up | synonym. "
+                "Applied as a final step after matching and prioritization. "
+                "If all=true, returns every match with this name_basis; if all=false, "
+                "returns the best (lowest-priority) match with this name_basis. "
+                "Default: no filter (all bases returned).",
             },
             "output_formats": ["json"],
             "methods": {
                 "GET": "Single query via URL parameters.",
                 "POST": "Batch query. Accepts either 1. a JSON array of up to 100 full "
-                "query objects, each with its own location; MatchOptions (all, basis) are "
+                "query objects, each with its own location; MatchOptions (all, name_basis) are "
                 "passed as query parameters; or 2. a JSON object with a single shared "
                 "location/options and a 'strat_names' list of (id, strat_name) pairs "
                 "(e.g. [[932043, 'Navajo'], [74382, 'Navajo Sandstone']]). Each supplied "
@@ -88,7 +91,7 @@ MATCH_STRAT_NAMES_INFO = {
                 "/dev/match/strat-names?strat_name=Jelm Formation&lat=40.9&lng=-105.6&interval=Triassic",
                 "/dev/match/strat-names?strat_name=Jelm Formation&lat=40.9&lng=-105.6&b_age=250.0&t_age=200.0",
                 "/dev/match/strat-names?strat_name=Jelm Formation&lat=40.9&lng=-105.6&b_interval=Triassic&t_interval=Jurassic",
-                "/dev/match/strat-names?strat_name=Navajo&lat=35.951&lng=-109.905&basis=column-units",
+                "/dev/match/strat-names?strat_name=Navajo Sandstone&lat=35.951&lng=-109.905&all=true&name_basis=rank-up",
                 "/dev/match/strat-names?strat_name=Kaza&lat=53.114&lng=-120.909&project_id=1",
                 "/dev/match/strat-names?strat_name=Halgaito Member&lat=35.951&lng=-109.905&identifier=sample-001",
                 "/dev/match/strat-names?strat_name_id=3361&lat=35.951&lng=-109.905",

--- a/services/api-v3/api/match/__init__.py
+++ b/services/api-v3/api/match/__init__.py
@@ -449,14 +449,22 @@ def match_units(
     opts = MatchOptions(**query.model_dump())
 
     db = get_database()
-    setup_matcher()
+    try:
+        setup_matcher()
 
-    results = []
-    match_data = build_match_data(db, params)
-    if match_data is not None:
-        results.append(match_data)
-        print("Match data results", results)
-    return generate_response(results, opts)
+        results = []
+        match_data = build_match_data(db, params)
+        if match_data is not None:
+            results.append(match_data)
+            print("Match data results", results)
+        return generate_response(results, opts)
+    finally:
+        # Release this thread's scoped session so its connection returns to the
+        # pool. Without this, queries run via db.run_query leave an open
+        # transaction (run_query never advances the underlying generator to its
+        # commit), leaking a connection per worker thread until the pool is
+        # exhausted.
+        db.session.remove()
 
 
 @router.post("/strat-names")
@@ -488,19 +496,24 @@ def match_units_multi(
         queries = body
 
     db = get_database()
-    setup_matcher()
+    try:
+        setup_matcher()
 
-    all_results: list[MatchData] = []
+        all_results: list[MatchData] = []
 
-    if len(queries) > 100:
-        raise ValueError("Maximum of 100 queries allowed per request.")
+        if len(queries) > 100:
+            raise ValueError("Maximum of 100 queries allowed per request.")
 
-    for params in queries:
-        match_data = build_match_data(db, params)
-        if match_data is not None:
-            all_results.append(match_data)
+        for params in queries:
+            match_data = build_match_data(db, params)
+            if match_data is not None:
+                all_results.append(match_data)
 
-    return generate_response(all_results, opts)
+        return generate_response(all_results, opts)
+    finally:
+        # Release this thread's scoped session so its connection returns to the
+        # pool (see match_units for details).
+        db.session.remove()
 
 
 def generate_response(

--- a/services/api-v3/api/match/__init__.py
+++ b/services/api-v3/api/match/__init__.py
@@ -70,40 +70,13 @@ class AbsoluteAgeConstraint(BaseModel):
     t_age: float = Field(None, description="Late/upper age constraint in Ma")
 
 
-class MatchQuery(BaseModel):
-    strat_name: str | None = Field(
-        None,
-        description="Text containing a stratigraphic name to match.",
-        examples=[
-            "Navajo Sandstone",
-            "Halgaito Member",
-            "Coconino",
-            "Dakota Formation",
-            "Matchless Amphibolite",
-            "broke neck pluton; Escapement Bay Fm",
-            "Morrison Fm",
-            "Kayenta Formation; Davis Branch Mbr; Wingate Sandstone",
-        ],
-    )
-    concept_name: str | None = Field(
-        None,
-        description="Text containing a concept name to match.",
-        examples=[
-            "Navajo",
-            "Dakota",
-            "Morrison",
-            "Kayenta",
-        ],
-    )
-    strat_name_id: int | None = Field(
-        None, description="A Macrostrat stratigraphic name ID to match directly."
-    )
-    concept_id: int | None = Field(
-        None, description="A Macrostrat concept ID to match directly."
-    )
-    identifier: str | int | None = Field(
-        None, description="An optional identifier to associate with this query."
-    )
+class MatchContext(BaseModel):
+    """Shared location, age, and priority fields used to constrain a match.
+
+    Factored out of MatchQuery so that both single queries and shared-location
+    batch queries (MatchBatchQuery) can reuse the same location/age handling.
+    """
+
     lat: float | None = None
     lng: float | None = None
     col_id: int | None = Field(
@@ -135,20 +108,6 @@ class MatchQuery(BaseModel):
             "matches prioritized before broader concept, rank-down, rank-up, or synonym matches."
         ),
     )
-
-    @model_validator(mode="after")
-    def validate_match_input(self):
-        """Ensure that either strat_name or strat_name_id is provided."""
-        if (
-            self.strat_name is None
-            and self.strat_name_id is None
-            and self.concept_id is None
-            and self.concept_name is None
-        ):
-            raise ValueError(
-                "Either strat_name/concept_name or strat_name_id/concept_id must be provided."
-            )
-        return self
 
     @model_validator(mode="after")
     def validate_position_info(self):
@@ -184,6 +143,56 @@ class MatchQuery(BaseModel):
         return AbsoluteAgeConstraint(b_age=b_age, t_age=t_age)
 
 
+class MatchQuery(MatchContext):
+    strat_name: str | None = Field(
+        None,
+        description="Text containing a stratigraphic name to match.",
+        examples=[
+            "Navajo Sandstone",
+            "Halgaito Member",
+            "Coconino",
+            "Dakota Formation",
+            "Matchless Amphibolite",
+            "broke neck pluton; Escapement Bay Fm",
+            "Morrison Fm",
+            "Kayenta Formation; Davis Branch Mbr; Wingate Sandstone",
+        ],
+    )
+    concept_name: str | None = Field(
+        None,
+        description="Text containing a concept name to match.",
+        examples=[
+            "Navajo",
+            "Dakota",
+            "Morrison",
+            "Kayenta",
+        ],
+    )
+    strat_name_id: int | None = Field(
+        None, description="A Macrostrat stratigraphic name ID to match directly."
+    )
+    concept_id: int | None = Field(
+        None, description="A Macrostrat concept ID to match directly."
+    )
+    identifier: str | int | None = Field(
+        None, description="An optional identifier to associate with this query."
+    )
+
+    @model_validator(mode="after")
+    def validate_match_input(self):
+        """Ensure that either strat_name or strat_name_id is provided."""
+        if (
+            self.strat_name is None
+            and self.strat_name_id is None
+            and self.concept_id is None
+            and self.concept_name is None
+        ):
+            raise ValueError(
+                "Either strat_name/concept_name or strat_name_id/concept_id must be provided."
+            )
+        return self
+
+
 class MatchMessageType(enum.Enum):
     Info = "info"
     Warning = "warning"
@@ -213,6 +222,11 @@ class MatchMessage(BaseModel):
 
 
 class MatchData(BaseModel):
+    id: str | int | None = Field(
+        None,
+        description="The identifier supplied with the input query, echoed back so "
+        "batch results can be correlated to their input.",
+    )
     unit_matches: list[MatchResult]
     messages: list[MatchMessage]
 
@@ -239,6 +253,68 @@ class MatchOptions(BaseModel):
 
 class MatchSingleQueryParams(MatchQuery, MatchOptions):
     pass
+
+
+class StratNameItem(BaseModel):
+    """A single (id, strat_name) pair in a shared-location batch query.
+
+    Accepts either a 2-element ``[id, strat_name]`` array (the JSON rendering of
+    an ``(id, strat_name)`` tuple) or an explicit ``{"id": ..., "strat_name": ...}``
+    object.
+    """
+
+    id: str | int = Field(
+        ..., description="User-supplied identifier, returned back in the result."
+    )
+    strat_name: str = Field(..., description="Stratigraphic name text to match.")
+
+    @model_validator(mode="before")
+    @classmethod
+    def coerce_pair(cls, data):
+        if isinstance(data, (list, tuple)):
+            if len(data) != 2:
+                raise ValueError(
+                    "Each strat_names entry must be an (id, strat_name) pair."
+                )
+            return {"id": data[0], "strat_name": data[1]}
+        return data
+
+
+class MatchBatchQuery(MatchContext, MatchOptions):
+    """A shared-location batch query.
+
+    A single location (``lat``/``lng`` or ``col_id``), age constraint, priority,
+    and set of match options are applied to every ``(id, strat_name)`` pair in
+    ``strat_names``. Each pair is expanded into an individual MatchQuery, and the
+    supplied ``id`` is echoed back on the corresponding result.
+    """
+
+    strat_names: list[StratNameItem] = Field(
+        ...,
+        description="List of (id, strat_name) pairs to match against the shared location.",
+        examples=[[[932043, "Navajo"], [74382, "Navajo Sandstone"], [382950, "Morrison"]]],
+    )
+
+    def to_queries(self) -> list["MatchQuery"]:
+        """Expand each (id, strat_name) pair into a MatchQuery sharing this context."""
+        shared = self.model_dump(
+            include={
+                "lat",
+                "lng",
+                "col_id",
+                "project_id",
+                "b_interval",
+                "t_interval",
+                "interval",
+                "b_age",
+                "t_age",
+                "priority",
+            }
+        )
+        return [
+            MatchQuery(strat_name=item.strat_name, identifier=item.id, **shared)
+            for item in self.strat_names
+        ]
 
 
 NameBasis = Literal["exact", "concept", "rank-down", "rank-up", "synonym"]
@@ -380,14 +456,32 @@ def match_units(
 
 @router.post("/strat-names")
 def match_units_multi(
-    body: list[MatchQuery],
+    body: list[MatchQuery] | MatchBatchQuery,
     query: Annotated[MatchOptions, Query()],
 ):
     """
     Match multiple stratigraphic name queries in a single request.
+
+    Two body shapes are accepted:
+
+    - A JSON **array** of full query objects, each carrying its own location and
+      options. MatchOptions (``all``, ``basis``) are read from query parameters.
+    - A JSON **object** (MatchBatchQuery) with a single shared location/options and
+      a ``strat_names`` list of ``(id, strat_name)`` pairs. Options are read from
+      the body, and each supplied ``id`` is echoed back on its result.
+
     :return: MatchAPIResponse
     """
-    opts = MatchOptions(**query.model_dump())
+    if isinstance(body, MatchBatchQuery):
+        # Shared-location batch: options come from the body, queries are expanded
+        # from the (id, strat_name) pairs.
+        opts = MatchOptions(all=body.all, basis=body.basis)
+        queries = body.to_queries()
+    else:
+        # Array of full query objects: options come from query parameters.
+        opts = MatchOptions(**query.model_dump())
+        queries = body
+
     if opts.basis is None:
         opts.basis = set(get_match_types(None))
 
@@ -396,10 +490,10 @@ def match_units_multi(
 
     all_results: list[MatchData] = []
 
-    if len(body) > 100:
+    if len(queries) > 100:
         raise ValueError("Maximum of 100 queries allowed per request.")
 
-    for params in body:
+    for params in queries:
         match_data = build_match_data(db, params)
         if match_data is not None:
             all_results.append(match_data)
@@ -413,6 +507,7 @@ def generate_response(
     if not opts.all:
         results = [
             MatchData(
+                id=result.id,
                 unit_matches=[m for m in result.unit_matches if m.priority == 0.0],
                 messages=result.messages,
             )
@@ -504,6 +599,7 @@ def build_match_data(db, params):
     if params.strat_name is not None and params.concept_name is not None:
         # Return an error result
         return MatchData(
+            id=params.identifier,
             unit_matches=[],
             messages=[
                 MatchMessage(
@@ -517,6 +613,7 @@ def build_match_data(db, params):
     if age_constraint.b_age < age_constraint.t_age:
         # Return an error result
         return MatchData(
+            id=params.identifier,
             unit_matches=[],
             messages=[
                 MatchMessage(
@@ -590,4 +687,4 @@ def build_match_data(db, params):
             )
         )
     results = assign_priorities(results, params.priority)
-    return MatchData(unit_matches=results, messages=messages)
+    return MatchData(id=params.identifier, unit_matches=results, messages=messages)

--- a/services/api-v3/api/match/__init__.py
+++ b/services/api-v3/api/match/__init__.py
@@ -9,11 +9,9 @@ from pydantic import BaseModel, Field, model_validator
 from macrostrat.match_utils import (
     MATCH_STRAT_NAMES_INFO,
     MatchResult,
-    MatchType,
     create_ignore_list,
     get_all_matched_units,
     get_columns_for_location,
-    get_match_types,
     standardize_names,
     standardize_names_from_id,
 )
@@ -180,7 +178,7 @@ class MatchQuery(MatchContext):
 
     @model_validator(mode="after")
     def validate_match_input(self):
-        """Ensure that either strat_name or strat_name_id is provided."""
+        """Ensure that exactly one of strat_name or strat_name_id is provided."""
         if (
             self.strat_name is None
             and self.strat_name_id is None
@@ -189,6 +187,10 @@ class MatchQuery(MatchContext):
         ):
             raise ValueError(
                 "Either strat_name/concept_name or strat_name_id/concept_id must be provided."
+            )
+        if self.strat_name is not None and self.strat_name_id is not None:
+            raise ValueError(
+                "Only one of strat_name or strat_name_id can be provided, not both."
             )
         return self
 
@@ -241,9 +243,16 @@ class MatchAPIResponse(BaseModel):
     messages: set[MatchMessage] | None = None
 
 
+NameBasis = Literal["exact", "concept", "rank-down", "rank-up", "synonym"]
+SpatialBasis = Literal["containing column", "adjacent column"]
+
+
 class MatchOptions(BaseModel):
-    basis: Optional[set[MatchType]] = Field(
-        None, description="Types of matches to include."
+    name_basis: Optional[NameBasis] = Field(
+        None,
+        description="If provided, filter results to only those whose name_basis "
+        "equals this value. One of: exact, concept, rank-down, rank-up, synonym. "
+        "Applied as a final step after matching and prioritization.",
     )
     all: bool = Field(
         False,
@@ -315,10 +324,6 @@ class MatchBatchQuery(MatchContext, MatchOptions):
             MatchQuery(strat_name=item.strat_name, identifier=item.id, **shared)
             for item in self.strat_names
         ]
-
-
-NameBasis = Literal["exact", "concept", "rank-down", "rank-up", "synonym"]
-SpatialBasis = Literal["containing column", "adjacent column"]
 
 
 class MatchPriorityOrder(BaseModel):
@@ -440,8 +445,6 @@ def match_units(
     # Reconstruct separated mixins
     params = MatchQuery(**query.model_dump())
     opts = MatchOptions(**query.model_dump())
-    if opts.basis is None:
-        opts.basis = set(get_match_types(None))
 
     db = get_database()
     setup_matcher()
@@ -465,7 +468,7 @@ def match_units_multi(
     Two body shapes are accepted:
 
     - A JSON **array** of full query objects, each carrying its own location and
-      options. MatchOptions (``all``, ``basis``) are read from query parameters.
+      options. MatchOptions (``all``, ``name_basis``) are read from query parameters.
     - A JSON **object** (MatchBatchQuery) with a single shared location/options and
       a ``strat_names`` list of ``(id, strat_name)`` pairs. Options are read from
       the body, and each supplied ``id`` is echoed back on its result.
@@ -475,15 +478,12 @@ def match_units_multi(
     if isinstance(body, MatchBatchQuery):
         # Shared-location batch: options come from the body, queries are expanded
         # from the (id, strat_name) pairs.
-        opts = MatchOptions(all=body.all, basis=body.basis)
+        opts = MatchOptions(all=body.all, name_basis=body.name_basis)
         queries = body.to_queries()
     else:
         # Array of full query objects: options come from query parameters.
         opts = MatchOptions(**query.model_dump())
         queries = body
-
-    if opts.basis is None:
-        opts.basis = set(get_match_types(None))
 
     db = get_database()
     setup_matcher()
@@ -504,15 +504,34 @@ def match_units_multi(
 def generate_response(
     results: list[MatchData], opts: MatchOptions, messages: list[MatchMessage] = None
 ) -> MatchAPIResponse:
-    if not opts.all:
+    # Filter by name_basis after matching/prioritization, keeping only matches
+    # whose name_basis equals the requested value.
+    if opts.name_basis is not None:
         results = [
             MatchData(
                 id=result.id,
-                unit_matches=[m for m in result.unit_matches if m.priority == 0.0],
+                unit_matches=[
+                    m for m in result.unit_matches if m.name_basis == opts.name_basis
+                ],
                 messages=result.messages,
             )
             for result in results
         ]
+
+    # When all=False, keep only the best (lowest-priority) match that remain.
+    # With no name_basis filter the best priority is 0.0, preserving prior behavior.
+    if not opts.all:
+        reduced: list[MatchData] = []
+        for result in results:
+            if result.unit_matches:
+                best = min(m.priority for m in result.unit_matches)
+                kept = [m for m in result.unit_matches if m.priority == best]
+            else:
+                kept = []
+            reduced.append(
+                MatchData(id=result.id, unit_matches=kept, messages=result.messages)
+            )
+        results = reduced
     _messages: set[MatchMessage] = set()
 
     for result in results:

--- a/services/api-v3/api/match/__init__.py
+++ b/services/api-v3/api/match/__init__.py
@@ -292,7 +292,9 @@ class MatchBatchQuery(MatchContext, MatchOptions):
     strat_names: list[StratNameItem] = Field(
         ...,
         description="List of (id, strat_name) pairs to match against the shared location.",
-        examples=[[[932043, "Navajo"], [74382, "Navajo Sandstone"], [382950, "Morrison"]]],
+        examples=[
+            [[932043, "Navajo"], [74382, "Navajo Sandstone"], [382950, "Morrison"]]
+        ],
     )
 
     def to_queries(self) -> list["MatchQuery"]:

--- a/services/api-v3/api/match/test_match_route.py
+++ b/services/api-v3/api/match/test_match_route.py
@@ -101,6 +101,101 @@ def test_basic_match_units_strat_name_priority(client, case):
     assert best_match["strat_name_id"] == case.strat_name_id
 
 
+def test_strat_name_and_strat_name_id_returns_error(client):
+    """Providing both strat_name and strat_name_id is rejected with a 422."""
+    response = client.get(
+        "/strat-names",
+        params={
+            "strat_name": "Navajo Sandstone",
+            "strat_name_id": 3361,
+            "lat": 39.419220,
+            "lng": -111.950684,
+        },
+    )
+    assert response.status_code == 422
+    body = response.text
+    assert "Only one of strat_name or strat_name_id" in body
+
+
+def test_name_basis_filter(client):
+    """name_basis filters results to only matches with that name_basis."""
+    #get all possible match bases with all=True so we know which bases are present.
+    full = client.get(
+        "/strat-names",
+        params={"col_id": 490, "strat_name": "Mancos", "all": True},
+    )
+    assert full.status_code == 200
+    full_matches = full.json()["results"][0]["unit_matches"]
+    present = {m["name_basis"] for m in full_matches}
+    assert present  # sanity: there is something to filter
+
+    #pick one basis to confirm the filter returns only that basis
+    target = sorted(present)[0]
+    expected = [m for m in full_matches if m["name_basis"] == target]
+
+    filtered = client.get(
+        "/strat-names",
+        params={
+            "col_id": 490,
+            "strat_name": "Mancos",
+            "all": True,
+            "name_basis": target,
+        },
+    )
+    assert filtered.status_code == 200
+    filtered_matches = filtered.json()["results"][0]["unit_matches"]
+    assert len(filtered_matches) == len(expected)
+    assert all(m["name_basis"] == target for m in filtered_matches)
+
+
+def test_name_basis_filter_all_false_returns_best_single_match(client):
+    """all=false + name_basis returns the best (lowest-priority) match of that basis."""
+    #get all possible match bases with all=True so we know which bases are present.
+    full = client.get(
+        "/strat-names",
+        params={"col_id": 490, "strat_name": "Mancos", "all": True},
+    )
+    assert full.status_code == 200
+    full_matches = full.json()["results"][0]["unit_matches"]
+    present = {m["name_basis"] for m in full_matches}
+    assert present
+
+    target = sorted(present)[0]
+    of_basis = [m for m in full_matches if m["name_basis"] == target]
+    best_priority = min(m["priority"] for m in of_basis)
+    expected_unit_ids = {m["unit_id"] for m in of_basis if m["priority"] == best_priority}
+
+    resp = client.get(
+        "/strat-names",
+        params={
+            "col_id": 490,
+            "strat_name": "Mancos",
+            "all": False,
+            "name_basis": target,
+        },
+    )
+    assert resp.status_code == 200
+    matches = resp.json()["results"][0]["unit_matches"]
+    assert len(matches) >= 1
+    # Only the best match of the requested basis are returned.
+    assert all(m["name_basis"] == target for m in matches)
+    assert all(m["priority"] == best_priority for m in matches)
+    assert {m["unit_id"] for m in matches} == expected_unit_ids
+
+
+def test_name_basis_invalid_value_returns_error(client):
+    """An unknown name_basis value is rejected with a 422."""
+    response = client.get(
+        "/strat-names",
+        params={
+            "col_id": 490,
+            "strat_name": "Mancos",
+            "name_basis": "not-a-basis",
+        },
+    )
+    assert response.status_code == 422
+
+
 def test_no_match_units(client):
     response = client.get(
         "/strat-names",

--- a/services/api-v3/api/match/test_match_route.py
+++ b/services/api-v3/api/match/test_match_route.py
@@ -150,6 +150,67 @@ def test_multi_match_units(client):
         assert best_match["strat_name_id"] == case.strat_name_id
 
 
+def test_batch_match_units_shared_location(client):
+    """POST a shared location plus a list of (id, strat_name) pairs.
+
+    Each input id should be echoed back on its result so callers can correlate,
+    and results should stay one-per-input in order.
+    """
+    pairs = [(1000 + i, c.match_text) for i, c in enumerate(cases)]
+    response = client.post(
+        "/strat-names",
+        json={
+            "strat_names": pairs,
+            "lat": cases[0].xy[1],
+            "lng": cases[0].xy[0],
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "results" in data
+
+    results = data["results"]
+    assert len(results) == len(cases)
+
+    for res, case, (pair_id, _name) in zip(results, cases, pairs):
+        # The supplied id is echoed back for correlation.
+        assert res["id"] == pair_id
+
+        matches = res["unit_matches"]
+        assert_valid_unit_matches(matches)
+
+        # Default all=false returns exactly one best-priority match per input.
+        assert len(matches) == 1
+        best_match = matches[0]
+        assert best_match["priority"] == 0.0
+        assert best_match["unit_id"] == case.unit_id
+        assert best_match["strat_name_id"] == case.strat_name_id
+
+
+def test_batch_match_units_col_id_and_all_in_body(client):
+    """Batch body accepts col_id instead of lat/lng and reads `all` from the body."""
+    response = client.post(
+        "/strat-names",
+        json={
+            "strat_names": [[42, "Mancos"]],
+            "col_id": 490,
+            "all": True,
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    results = data["results"]
+    assert len(results) == 1
+    assert results[0]["id"] == 42
+
+    matches = results[0]["unit_matches"]
+    assert_valid_unit_matches(matches)
+    # all=true (read from the body) should return more than the single best match.
+    priorities = [m["priority"] for m in matches]
+    assert priorities == sorted(priorities)
+    assert len(matches) > 1
+
+
 def test_match_units_ambiguous_column(client):
     response = client.get(
         "/strat-names",

--- a/services/api-v3/api/match/test_match_route.py
+++ b/services/api-v3/api/match/test_match_route.py
@@ -119,7 +119,7 @@ def test_strat_name_and_strat_name_id_returns_error(client):
 
 def test_name_basis_filter(client):
     """name_basis filters results to only matches with that name_basis."""
-    #get all possible match bases with all=True so we know which bases are present.
+    # get all possible match bases with all=True so we know which bases are present.
     full = client.get(
         "/strat-names",
         params={"col_id": 490, "strat_name": "Mancos", "all": True},
@@ -129,7 +129,7 @@ def test_name_basis_filter(client):
     present = {m["name_basis"] for m in full_matches}
     assert present  # sanity: there is something to filter
 
-    #pick one basis to confirm the filter returns only that basis
+    # pick one basis to confirm the filter returns only that basis
     target = sorted(present)[0]
     expected = [m for m in full_matches if m["name_basis"] == target]
 
@@ -150,7 +150,7 @@ def test_name_basis_filter(client):
 
 def test_name_basis_filter_all_false_returns_best_single_match(client):
     """all=false + name_basis returns the best (lowest-priority) match of that basis."""
-    #get all possible match bases with all=True so we know which bases are present.
+    # get all possible match bases with all=True so we know which bases are present.
     full = client.get(
         "/strat-names",
         params={"col_id": 490, "strat_name": "Mancos", "all": True},
@@ -163,7 +163,9 @@ def test_name_basis_filter_all_false_returns_best_single_match(client):
     target = sorted(present)[0]
     of_basis = [m for m in full_matches if m["name_basis"] == target]
     best_priority = min(m["priority"] for m in of_basis)
-    expected_unit_ids = {m["unit_id"] for m in of_basis if m["priority"] == best_priority}
+    expected_unit_ids = {
+        m["unit_id"] for m in of_basis if m["priority"] == best_priority
+    }
 
     resp = client.get(
         "/strat-names",


### PR DESCRIPTION
## Summary

* The API now rejects requests that include both `strat_name` and `strat_name_id`.

  * Previously, both could be sent together, which made the behavior unclear.
  * Now, users must provide one or the other.

* The old `basis` parameter has been replaced with `name_basis`.

  * `name_basis` now works as an actual filter on the returned matches.
  * Valid options are: `exact`, `concept`, `rank-down`, `rank-up`, and `synonym`.
  * Invalid values now return a clear error.

* A database connection leak was fixed.

  * The Match API was sometimes exhausting the database connection pool during tests.
  * Each request now properly releases its database session after it finishes.
  * This resolves the intermittent timeout errors seen in the match test suite.

### Tests added

* Checks that `strat_name` and `strat_name_id` cannot be used together.
* Checks that `name_basis` filters results correctly.
* Checks that `name_basis` works when only the best match is requested.
* Checks that invalid `name_basis` values return an error.

