### PR TITLE
API v3 database lifecycle fix

### DIFF
--- a/services/api-v3/api/app.py
+++ b/services/api-v3/api/app.py
@@ -9,7 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 dotenv.load_dotenv()
 
 import api.routes.security
-from api.database import connect_engine, dispose_engine
+from api.database import build_async_engine, build_sync_database
 from api.map import router as map_router
 from api.match import router as match_router
 from api.routes.ingest import router as ingest_router
@@ -19,10 +19,18 @@ from api.routes.sources import router as sources_router
 
 @asynccontextmanager
 async def setup_engine(app: FastAPI):
-    """Return database client instance."""
-    app.state.engine = await connect_engine()
+    """Create the shared database connection pools for the app's lifetime.
+
+    Both the async engine and the sync Database own a connection pool, so they
+    are built exactly once here and shared across all requests via app.state
+    (see api/database.py dependencies). They are disposed on shutdown so their
+    connections are returned to Postgres rather than leaked.
+    """
+    app.state.engine = build_async_engine()
+    app.state.sync_db = build_sync_database()
     yield
-    await dispose_engine()
+    await app.state.engine.dispose()
+    app.state.sync_db.engine.dispose()
 
 
 app = FastAPI(

--- a/services/api-v3/api/app.py
+++ b/services/api-v3/api/app.py
@@ -9,7 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 dotenv.load_dotenv()
 
 import api.routes.security
-from api.database import build_async_engine, build_sync_database
+from api.database import AppDatabase, get_db_url
 from api.map import router as map_router
 from api.match import router as match_router
 from api.routes.ingest import router as ingest_router
@@ -18,19 +18,17 @@ from api.routes.sources import router as sources_router
 
 
 @asynccontextmanager
-async def setup_engine(app: FastAPI):
+async def setup_engine(app: FastAPI, url: str | None = None):
     """Create the shared database connection pools for the app's lifetime.
 
-    Both the async engine and the sync Database own a connection pool, so they
-    are built exactly once here and shared across all requests via app.state
-    (see api/database.py dependencies). They are disposed on shutdown so their
+    The unified ``Database`` owns both the async and sync connection pools, so it
+    is built exactly once here and shared across all requests via ``app.state.db``
+    (see api/database.py dependencies). It is disposed on shutdown so its
     connections are returned to Postgres rather than leaked.
     """
-    app.state.engine = build_async_engine()
-    app.state.sync_db = build_sync_database()
+    app.state.db = AppDatabase(url or get_db_url())
     yield
-    await app.state.engine.dispose()
-    app.state.sync_db.engine.dispose()
+    await app.state.db.dispose()
 
 
 app = FastAPI(

--- a/services/api-v3/api/database.py
+++ b/services/api-v3/api/database.py
@@ -6,17 +6,18 @@
 # On the bottom you will find the methods that do not use this method
 #
 import datetime
-from contextvars import ContextVar
 from os import environ
-from typing import Literal, Type
+from typing import Annotated, Iterator, Literal, Type
 
 import api.schemas as schemas
 from api.query_parser import QueryParser
 from dotenv import load_dotenv
+from fastapi import Depends, Request
 from pydantic import BaseModel
 from sqlalchemy import CursorResult, MetaData, Table, func, insert, select, text, update
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import (
+    AsyncConnection,
     AsyncEngine,
     AsyncSession,
     async_sessionmaker,
@@ -27,16 +28,18 @@ from macrostrat.database import Database
 
 load_dotenv()
 
-# Context variables are thread-safe, so are a better choice
-# than using a global variables (I think/hope)
-_db_ctx: ContextVar[Database | None] = ContextVar("db_ctx", default=None)
-_async_db_ctx: ContextVar[AsyncEngine | None] = ContextVar("async_db_ctx", default=None)
 
+def get_engine(request: Request) -> AsyncEngine:
+    """FastAPI dependency returning the process-wide async engine.
 
-def get_engine() -> AsyncEngine:
-    engine = _async_db_ctx.get()
+    The engine (and its connection pool) is created once in the app lifespan and
+    stored on ``app.state`` — see ``api/app.py``. Handlers must receive it via
+    injection rather than creating their own, which is what previously leaked a
+    pool per request and exhausted Postgres connections.
+    """
+    engine = getattr(request.app.state, "engine", None)
     if engine is None:
-        return _connect_engine_sync()
+        raise RuntimeError("Async engine not initialized; check the app lifespan")
     return engine
 
 
@@ -51,36 +54,54 @@ def get_db_url():
     raise ValueError("No database URL found")
 
 
-def get_sync_database():
-    """Get the synchronous database connection from the context variable."""
-    sync_db = _db_ctx.get()
+def get_sync_database(request: Request) -> Iterator[Database]:
+    """FastAPI dependency yielding the process-wide synchronous ``Database``.
+
+    Like the async engine, this is built once in the app lifespan and stored on
+    ``app.state`` so every request shares one connection pool.
+
+    ``Database.run_query`` leaves the thread-local session's transaction open
+    (it never advances its internal generator to the commit), which keeps a
+    connection checked out. Now that the pool is shared across all requests
+    rather than recreated per request, that would exhaust the pool — so we
+    release the scoped session here once the request finishes, returning its
+    connection to the pool.
+    """
+    sync_db = getattr(request.app.state, "sync_db", None)
     if sync_db is None:
-        sync_db = Database(get_db_url())
-        _db_ctx.set(sync_db)
-    return sync_db
+        raise RuntimeError("Sync database not initialized; check the app lifespan")
+    try:
+        yield sync_db
+    finally:
+        sync_db.session.remove()
 
 
-async def connect_engine() -> AsyncEngine:
-    # Make sure this is all run async in FastAPI lifecycle
-    return _connect_engine_sync()
+# Pool configuration shared by the async engine and the sync Database. A single
+# engine/pool is created per process in the app lifespan; ``pool_pre_ping``
+# recycles connections dropped by the server instead of raising on first use.
+_POOL_KWARGS = dict(
+    pool_size=5,
+    max_overflow=10,
+    pool_pre_ping=True,
+    pool_recycle=1800,
+)
 
 
-def _connect_engine_sync():
-    # Check the uri and DB_URL for the database connection string
-    # uri is how the Postgres Operator passes, DB_URL is nicer for .env files
+def build_async_engine() -> AsyncEngine:
+    """Build the async engine. Call once, in the app lifespan."""
     db_url = get_db_url()
     if db_url.startswith("postgresql://"):
         db_url = db_url.replace("postgresql://", "postgresql+asyncpg://", 1)
-    engine = create_async_engine(db_url)
-    _async_db_ctx.set(engine)
-    return engine
+    return create_async_engine(db_url, **_POOL_KWARGS)
 
 
-async def dispose_engine():
-    engine = _async_db_ctx.get()
-    if engine is not None:
-        await engine.dispose()
-        _async_db_ctx.set(None)
+def build_sync_database() -> Database:
+    """Build the sync Database. Call once, in the app lifespan."""
+    return Database(get_db_url(), **_POOL_KWARGS)
+
+
+EngineDep = Annotated[AsyncEngine, Depends(get_engine)]
+SyncDatabaseDep = Annotated[Database, Depends(get_sync_database)]
 
 
 def get_async_session(
@@ -89,17 +110,22 @@ def get_async_session(
     return async_sessionmaker(engine, **kwargs)
 
 
-async def source_id_to_slug(async_engine: AsyncEngine, source_id: id):
-    async with get_async_session(async_engine)() as session:
-        stmt = select(schemas.Sources).where(schemas.Sources.source_id == source_id)
-        result = await session.scalar(stmt)
+async def source_id_to_slug(conn: AsyncConnection, source_id: int):
+    """Look up a source's slug, reusing an existing connection.
 
-        if result is None:
-            raise NoResultFound(
-                f"Could not find primary_table corresponding with source_id: {source_id}"
-            )
+    Takes a live connection rather than the engine so callers that already hold
+    one (e.g. ``get_table``) don't acquire a second pooled connection while the
+    first is still checked out.
+    """
+    stmt = select(schemas.Sources.slug).where(schemas.Sources.source_id == source_id)
+    slug = (await conn.execute(stmt)).scalar()
 
-        return result.slug
+    if slug is None:
+        raise NoResultFound(
+            f"Could not find primary_table corresponding with source_id: {source_id}"
+        )
+
+    return slug
 
 
 async def get_sources(
@@ -211,7 +237,7 @@ async def get_table(
     conn, table_id: int, geometry_type: Literal["polygons", "points", "lines"]
 ) -> Table:
     metadata = MetaData(schema="sources")
-    table_slug = await source_id_to_slug(get_engine(), table_id)
+    table_slug = await source_id_to_slug(conn, table_id)
     table_name = f"{table_slug}_{geometry_type}"
     table = await conn.run_sync(
         lambda sync_conn: Table(table_name, metadata, autoload_with=sync_conn)

--- a/services/api-v3/api/database.py
+++ b/services/api-v3/api/database.py
@@ -29,20 +29,6 @@ from macrostrat.database import Database
 load_dotenv()
 
 
-def get_engine(request: Request) -> AsyncEngine:
-    """FastAPI dependency returning the process-wide async engine.
-
-    The engine (and its connection pool) is created once in the app lifespan and
-    stored on ``app.state`` — see ``api/app.py``. Handlers must receive it via
-    injection rather than creating their own, which is what previously leaked a
-    pool per request and exhausted Postgres connections.
-    """
-    engine = getattr(request.app.state, "engine", None)
-    if engine is None:
-        raise RuntimeError("Async engine not initialized; check the app lifespan")
-    return engine
-
-
 def get_db_url():
     # Try several options ot get a database URL
     # - MACROSTRAT_DATABASE_URL is used by PyTest embedded in the macrostrat cli
@@ -54,29 +40,7 @@ def get_db_url():
     raise ValueError("No database URL found")
 
 
-def get_sync_database(request: Request) -> Iterator[Database]:
-    """FastAPI dependency yielding the process-wide synchronous ``Database``.
-
-    Like the async engine, this is built once in the app lifespan and stored on
-    ``app.state`` so every request shares one connection pool.
-
-    ``Database.run_query`` leaves the thread-local session's transaction open
-    (it never advances its internal generator to the commit), which keeps a
-    connection checked out. Now that the pool is shared across all requests
-    rather than recreated per request, that would exhaust the pool — so we
-    release the scoped session here once the request finishes, returning its
-    connection to the pool.
-    """
-    sync_db = getattr(request.app.state, "sync_db", None)
-    if sync_db is None:
-        raise RuntimeError("Sync database not initialized; check the app lifespan")
-    try:
-        yield sync_db
-    finally:
-        sync_db.session.remove()
-
-
-# Pool configuration shared by the async engine and the sync Database. A single
+# Pool configuration shared by the async engine and the sync database. A single
 # engine/pool is created per process in the app lifespan; ``pool_pre_ping``
 # recycles connections dropped by the server instead of raising on first use.
 _POOL_KWARGS = dict(
@@ -87,27 +51,79 @@ _POOL_KWARGS = dict(
 )
 
 
-def build_async_engine() -> AsyncEngine:
-    """Build the async engine. Call once, in the app lifespan."""
-    db_url = get_db_url()
-    if db_url.startswith("postgresql://"):
-        db_url = db_url.replace("postgresql://", "postgresql+asyncpg://", 1)
-    return create_async_engine(db_url, **_POOL_KWARGS)
+class AppDatabase:
+    """Application-scoped async + sync connection pool manager, one per process.
+
+    Pure integration sugar: it owns a SQLAlchemy async engine and the sync
+    ``macrostrat.database.Database`` and exposes parallel accessors so route
+    handlers can obtain whichever context they need — an async session/connection
+    or the sync database — from the app/request scope in a standard way. It is
+    *not* meant to be threaded into utility functions; those should take a
+    concrete sync or async context (an engine, sessionmaker, connection, or the
+    sync ``Database``) instead. Built once in the app lifespan and shared via
+    ``app.state.db`` — see ``api/app.py``.
+    """
+
+    def __init__(self, url: str):
+        async_url = url
+        if async_url.startswith("postgresql://"):
+            async_url = async_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+
+        self.async_engine: AsyncEngine = create_async_engine(async_url, **_POOL_KWARGS)
+        # expire_on_commit=False keeps ORM objects usable after commit (the
+        # recommended async default) so handlers can return them post-commit.
+        self.async_sessionmaker: async_sessionmaker[AsyncSession] = async_sessionmaker(
+            self.async_engine, expire_on_commit=False
+        )
+        self.sync: Database = Database(url, **_POOL_KWARGS)
+
+    # --- async accessors ---
+    def async_session(self, **kwargs) -> AsyncSession:
+        """A fresh ``AsyncSession`` context manager: ``async with db.async_session() as s``."""
+        return self.async_sessionmaker(**kwargs)
+
+    def async_connection(self):
+        """A transactional ``AsyncConnection`` context manager (``engine.begin()``)."""
+        return self.async_engine.begin()
+
+    # --- sync accessors ---
+    @property
+    def sync_engine(self):
+        return self.sync.engine
+
+    def sync_session(self):
+        """A transactional sync ``Session`` context manager."""
+        return self.sync.session_scope()
+
+    def sync_connection(self):
+        """A transactional sync ``Connection`` context manager (``engine.begin()``)."""
+        return self.sync.engine.begin()
+
+    async def dispose(self):
+        """Dispose both connection pools. Call once, on app shutdown."""
+        await self.async_engine.dispose()
+        self.sync.engine.dispose()
 
 
-def build_sync_database() -> Database:
-    """Build the sync Database. Call once, in the app lifespan."""
-    return Database(get_db_url(), **_POOL_KWARGS)
+def get_database(request: Request) -> Iterator[AppDatabase]:
+    """FastAPI dependency yielding the process-wide ``AppDatabase``.
+
+    The sync ``run_query`` helper leaves its thread-local session's transaction
+    open (it never advances its internal generator to the commit), keeping a
+    connection checked out. Since the pool is shared across all requests, we
+    release the scoped session when the request finishes so its connection
+    returns to the pool.
+    """
+    database = getattr(request.app.state, "db", None)
+    if database is None:
+        raise RuntimeError("Database not initialized; check the app lifespan")
+    try:
+        yield database
+    finally:
+        database.sync.session.remove()
 
 
-EngineDep = Annotated[AsyncEngine, Depends(get_engine)]
-SyncDatabaseDep = Annotated[Database, Depends(get_sync_database)]
-
-
-def get_async_session(
-    engine: AsyncEngine, **kwargs
-) -> async_sessionmaker[AsyncSession]:
-    return async_sessionmaker(engine, **kwargs)
+DatabaseDep = Annotated[AppDatabase, Depends(get_database)]
 
 
 async def source_id_to_slug(conn: AsyncConnection, source_id: int):

--- a/services/api-v3/api/map/__init__.py
+++ b/services/api-v3/api/map/__init__.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 
 import morecantile
-from api.database import SyncDatabaseDep
+from api.database import DatabaseDep
 from fastapi import APIRouter, Depends, HTTPException
 from morecantile import Tile
 from shapely import GEOSException
@@ -114,7 +114,7 @@ def get_compilation(compilation: str) -> str:
 def get_map_legend(
     compilation: Annotated[str, Depends(get_compilation)],
     map_area: Annotated[MapAreaInfo, Depends(map_area_params)],
-    db: SyncDatabaseDep,
+    database: DatabaseDep,
 ):
     """Get the legend for a given map compilation."""
 
@@ -127,7 +127,7 @@ def get_map_legend(
         )
 
     res = (
-        db.run_query(
+        database.sync.run_query(
             """
         WITH polygons AS (
             SELECT legend_id, source_id, scale

--- a/services/api-v3/api/map/__init__.py
+++ b/services/api-v3/api/map/__init__.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 
 import morecantile
-from api.database import get_sync_database
+from api.database import SyncDatabaseDep
 from fastapi import APIRouter, Depends, HTTPException
 from morecantile import Tile
 from shapely import GEOSException
@@ -114,10 +114,9 @@ def get_compilation(compilation: str) -> str:
 def get_map_legend(
     compilation: Annotated[str, Depends(get_compilation)],
     map_area: Annotated[MapAreaInfo, Depends(map_area_params)],
+    db: SyncDatabaseDep,
 ):
     """Get the legend for a given map compilation."""
-
-    db = get_sync_database()
 
     scale = scale_for_zoom(map_area.zoom)
 

--- a/services/api-v3/api/match/__init__.py
+++ b/services/api-v3/api/match/__init__.py
@@ -17,7 +17,7 @@ from macrostrat.match_utils import (
 )
 from macrostrat.match_utils.strat_names import get_ignore_list
 
-from ..database import get_sync_database as get_database
+from ..database import SyncDatabaseDep
 
 
 class Interval(BaseModel):
@@ -45,9 +45,8 @@ def setup_intervals(db):
     _intervals.set(interval_list)
 
 
-def setup_matcher():
+def setup_matcher(db):
     """Setup function to initialize matcher resources."""
-    db = get_database()
     try:
         ignore = get_ignore_list()
         return
@@ -393,6 +392,7 @@ def match_info():
 @router.get("/strat-names")
 def match_units(
     query: Annotated[MatchSingleQueryParams, Query()],
+    db: SyncDatabaseDep,
 ) -> MatchAPIResponse:
     """
     Match stratigraphic name text to the Macrostrat lexicon and columns.
@@ -401,9 +401,8 @@ def match_units(
     params = MatchQuery(**query.model_dump())
     opts = MatchOptions(**query.model_dump())
 
-    db = get_database()
     try:
-        setup_matcher()
+        setup_matcher(db)
 
         results = []
         match_data = build_match_data(db, params)
@@ -424,6 +423,7 @@ def match_units(
 def match_units_multi(
     body: list[MatchQueryFields],
     defaults: Annotated[MatchDefaults, Query()],
+    db: SyncDatabaseDep,
 ) -> MatchAPIResponse:
     """
     Match a batch of stratigraphic name queries in a single request.
@@ -461,9 +461,8 @@ def match_units_multi(
                 detail=[{**e, "index": index} for e in err.errors()],
             )
 
-    db = get_database()
     try:
-        setup_matcher()
+        setup_matcher(db)
 
         all_results: list[MatchData] = []
         for params in queries:

--- a/services/api-v3/api/match/__init__.py
+++ b/services/api-v3/api/match/__init__.py
@@ -17,7 +17,7 @@ from macrostrat.match_utils import (
 )
 from macrostrat.match_utils.strat_names import get_ignore_list
 
-from ..database import SyncDatabaseDep
+from ..database import DatabaseDep
 
 
 class Interval(BaseModel):
@@ -392,7 +392,7 @@ def match_info():
 @router.get("/strat-names")
 def match_units(
     query: Annotated[MatchSingleQueryParams, Query()],
-    db: SyncDatabaseDep,
+    database: DatabaseDep,
 ) -> MatchAPIResponse:
     """
     Match stratigraphic name text to the Macrostrat lexicon and columns.
@@ -401,6 +401,7 @@ def match_units(
     params = MatchQuery(**query.model_dump())
     opts = MatchOptions(**query.model_dump())
 
+    db = database.sync
     try:
         setup_matcher(db)
 
@@ -423,7 +424,7 @@ def match_units(
 def match_units_multi(
     body: list[MatchQueryFields],
     defaults: Annotated[MatchDefaults, Query()],
-    db: SyncDatabaseDep,
+    database: DatabaseDep,
 ) -> MatchAPIResponse:
     """
     Match a batch of stratigraphic name queries in a single request.
@@ -461,6 +462,7 @@ def match_units_multi(
                 detail=[{**e, "index": index} for e in err.errors()],
             )
 
+    db = database.sync
     try:
         setup_matcher(db)
 

--- a/services/api-v3/api/match/test_match_route.py
+++ b/services/api-v3/api/match/test_match_route.py
@@ -11,6 +11,7 @@ from macrostrat.match_utils.test_match_strat_names import (
 )
 
 from . import MatchQuery, router, setup_intervals
+from ..app import setup_engine
 
 # TODO: just import the enums from the parent module
 valid_name_bases = {"exact", "concept", "rank-up", "rank-down", "synonym"}
@@ -34,9 +35,12 @@ def assert_valid_unit_matches(matches):
 @fixture(scope="module")
 def client(env_db):
     environ["MACROSTRAT_DATABASE_URL"] = raw_database_url(env_db.engine.url)
-    test_app = FastAPI()
+    test_app = FastAPI(lifespan=setup_engine)
     test_app.include_router(router)
-    return TestClient(test_app, raise_server_exceptions=True)
+    # Enter the TestClient as a context manager so Starlette runs the lifespan,
+    # which populates app.state.sync_db that the match routes depend on.
+    with TestClient(test_app, raise_server_exceptions=True) as client:
+        yield client
 
 
 def test_match_units_no_params(client):

--- a/services/api-v3/api/match/test_match_route.py
+++ b/services/api-v3/api/match/test_match_route.py
@@ -10,8 +10,8 @@ from macrostrat.match_utils.test_match_strat_names import (
     cases_strat_name_priority,
 )
 
-from . import MatchQuery, router, setup_intervals
 from ..app import setup_engine
+from . import MatchQuery, router, setup_intervals
 
 # TODO: just import the enums from the parent module
 valid_name_bases = {"exact", "concept", "rank-up", "rank-down", "synonym"}

--- a/services/api-v3/api/routes/ingest.py
+++ b/services/api-v3/api/routes/ingest.py
@@ -7,7 +7,7 @@ import api.schemas as schemas
 import minio
 import starlette.requests
 from api.celery_app import celery_app
-from api.database import EngineDep, get_async_session
+from api.database import DatabaseDep
 from api.query_parser import QueryParser, get_filter_query_params
 from api.routes.security import has_access
 from api.schemas import IngestProcess as IngestProcessSchema
@@ -110,20 +110,18 @@ async def delete_map(
 @router.get("", response_model=list[IngestProcessModel.Get])
 async def get_multiple_ingest_process(
     response: Response,
-    engine: EngineDep,
+    database: DatabaseDep,
     page: int = 0,
     page_size: int = 50,
     filter_query_params=Depends(get_filter_query_params),
 ):
     """Get all ingestion processes"""
 
-    async_session = get_async_session(engine)
-
     query_parser = QueryParser(
         columns=IngestProcessSchema.__table__.c, query_params=filter_query_params
     )
 
-    async with async_session() as session:
+    async with database.async_session() as session:
 
         select_stmt = (
             select(IngestProcessSchema)
@@ -160,12 +158,10 @@ async def get_multiple_ingest_process(
 
 
 @router.get("/tags", response_model=list[str])
-async def get_all_tags(engine: EngineDep):
+async def get_all_tags(database: DatabaseDep):
     """Get all tags"""
 
-    async_session = get_async_session(engine)
-
-    async with async_session() as session:
+    async with database.async_session() as session:
         select_stmt = select(IngestProcessTag.tag).distinct()
         results = await session.execute(select_stmt)
 
@@ -173,12 +169,10 @@ async def get_all_tags(engine: EngineDep):
 
 
 @router.get("/{id}", response_model=IngestProcessModel.Get)
-async def get_ingest_process(id: int, engine: EngineDep):
+async def get_ingest_process(id: int, database: DatabaseDep):
     """Get a single object"""
 
-    async_session = get_async_session(engine)
-
-    async with async_session() as session:
+    async with database.async_session() as session:
         select_stmt = (
             select(IngestProcessSchema)
             .where(and_(IngestProcessSchema.id == id))
@@ -203,7 +197,7 @@ async def get_ingest_process(id: int, engine: EngineDep):
 @router.post("", response_model=IngestProcessModel.Get)
 async def create_ingest_process(
     object: IngestProcessModel.Post,
-    engine: EngineDep,
+    database: DatabaseDep,
     user_has_access: bool = Depends(has_access),
 ):
     """Create/Register a new object"""
@@ -213,9 +207,7 @@ async def create_ingest_process(
             status_code=403, detail="User does not have access to create an object"
         )
 
-    async_session = get_async_session(engine, expire_on_commit=False)
-
-    async with async_session() as session:
+    async with database.async_session() as session:
 
         if object.tags is None:
             object.tags = []
@@ -236,7 +228,7 @@ async def create_ingest_process(
 async def patch_ingest_process(
     id: int,
     object: IngestProcessModel.Patch,
-    engine: EngineDep,
+    database: DatabaseDep,
     user_has_access: bool = Depends(has_access),
 ):
     """Update a object"""
@@ -246,9 +238,7 @@ async def patch_ingest_process(
             status_code=403, detail="User does not have access to create an object"
         )
 
-    async_session = get_async_session(engine)
-
-    async with async_session() as session:
+    async with database.async_session() as session:
         update_stmt = (
             update(IngestProcessSchema)
             .where(IngestProcessSchema.id == id)
@@ -267,7 +257,7 @@ async def patch_ingest_process(
 async def add_ingest_process_tag(
     id: int,
     tag: IngestProcessModel.Tag,
-    engine: EngineDep,
+    database: DatabaseDep,
     user_has_access: bool = Depends(has_access),
 ):
     """Add a tag to an ingest process"""
@@ -277,9 +267,7 @@ async def add_ingest_process_tag(
             status_code=403, detail="User does not have access to create an object"
         )
 
-    async_session = get_async_session(engine)
-
-    async with async_session() as session:
+    async with database.async_session() as session:
 
         ingest_process = await session.get(IngestProcessSchema, id)
 
@@ -301,7 +289,7 @@ async def add_ingest_process_tag(
 async def delete_ingest_process_tag(
     id: int,
     tag: str,
-    engine: EngineDep,
+    database: DatabaseDep,
     user_has_access: bool = Depends(has_access),
 ):
     """Delete a tag from an ingest process"""
@@ -311,9 +299,7 @@ async def delete_ingest_process_tag(
             status_code=403, detail="User does not have access to create an object"
         )
 
-    async_session = get_async_session(engine)
-
-    async with async_session() as session:
+    async with database.async_session() as session:
 
         ingest_process = await session.get(IngestProcessSchema, id)
 
@@ -336,12 +322,10 @@ async def delete_ingest_process_tag(
 
 
 @router.get("/{id}/objects", response_model=list[Object.GetSecureURL])
-async def get_ingest_process_objects(id: int, engine: EngineDep):
+async def get_ingest_process_objects(id: int, database: DatabaseDep):
     """Get all objects for an ingestion process"""
 
-    async_session = get_async_session(engine)
-
-    async with async_session() as session:
+    async with database.async_session() as session:
 
         select_stmt = select(IngestProcessSchema).where(
             and_(IngestProcessSchema.id == id)
@@ -389,7 +373,7 @@ async def create_object(
     request: starlette.requests.Request,
     id: int,
     object: list[UploadFile],
-    engine: EngineDep,
+    database: DatabaseDep,
     user_has_access: bool = Depends(has_access),
 ):
     """Create/Register a new object"""
@@ -399,11 +383,9 @@ async def create_object(
             status_code=403, detail="User does not have access to create object"
         )
 
-    async_session = get_async_session(engine)
-
     response_objects = []
 
-    async with async_session() as session:
+    async with database.async_session() as session:
 
         ingest_stmt = select(IngestProcessSchema).where(IngestProcessSchema.id == id)
         ingest_process = await session.scalar(ingest_stmt)

--- a/services/api-v3/api/routes/ingest.py
+++ b/services/api-v3/api/routes/ingest.py
@@ -7,7 +7,7 @@ import api.schemas as schemas
 import minio
 import starlette.requests
 from api.celery_app import celery_app
-from api.database import get_async_session, get_engine
+from api.database import EngineDep, get_async_session
 from api.query_parser import QueryParser, get_filter_query_params
 from api.routes.security import has_access
 from api.schemas import IngestProcess as IngestProcessSchema
@@ -110,13 +110,13 @@ async def delete_map(
 @router.get("", response_model=list[IngestProcessModel.Get])
 async def get_multiple_ingest_process(
     response: Response,
+    engine: EngineDep,
     page: int = 0,
     page_size: int = 50,
     filter_query_params=Depends(get_filter_query_params),
 ):
     """Get all ingestion processes"""
 
-    engine = get_engine()
     async_session = get_async_session(engine)
 
     query_parser = QueryParser(
@@ -160,10 +160,9 @@ async def get_multiple_ingest_process(
 
 
 @router.get("/tags", response_model=list[str])
-async def get_all_tags():
+async def get_all_tags(engine: EngineDep):
     """Get all tags"""
 
-    engine = get_engine()
     async_session = get_async_session(engine)
 
     async with async_session() as session:
@@ -174,10 +173,9 @@ async def get_all_tags():
 
 
 @router.get("/{id}", response_model=IngestProcessModel.Get)
-async def get_ingest_process(id: int):
+async def get_ingest_process(id: int, engine: EngineDep):
     """Get a single object"""
 
-    engine = get_engine()
     async_session = get_async_session(engine)
 
     async with async_session() as session:
@@ -204,7 +202,9 @@ async def get_ingest_process(id: int):
 
 @router.post("", response_model=IngestProcessModel.Get)
 async def create_ingest_process(
-    object: IngestProcessModel.Post, user_has_access: bool = Depends(has_access)
+    object: IngestProcessModel.Post,
+    engine: EngineDep,
+    user_has_access: bool = Depends(has_access),
 ):
     """Create/Register a new object"""
 
@@ -213,7 +213,6 @@ async def create_ingest_process(
             status_code=403, detail="User does not have access to create an object"
         )
 
-    engine = get_engine()
     async_session = get_async_session(engine, expire_on_commit=False)
 
     async with async_session() as session:
@@ -237,6 +236,7 @@ async def create_ingest_process(
 async def patch_ingest_process(
     id: int,
     object: IngestProcessModel.Patch,
+    engine: EngineDep,
     user_has_access: bool = Depends(has_access),
 ):
     """Update a object"""
@@ -246,7 +246,6 @@ async def patch_ingest_process(
             status_code=403, detail="User does not have access to create an object"
         )
 
-    engine = get_engine()
     async_session = get_async_session(engine)
 
     async with async_session() as session:
@@ -266,7 +265,10 @@ async def patch_ingest_process(
 
 @router.post("/{id}/tags", response_model=list[str])
 async def add_ingest_process_tag(
-    id: int, tag: IngestProcessModel.Tag, user_has_access: bool = Depends(has_access)
+    id: int,
+    tag: IngestProcessModel.Tag,
+    engine: EngineDep,
+    user_has_access: bool = Depends(has_access),
 ):
     """Add a tag to an ingest process"""
 
@@ -275,7 +277,6 @@ async def add_ingest_process_tag(
             status_code=403, detail="User does not have access to create an object"
         )
 
-    engine = get_engine()
     async_session = get_async_session(engine)
 
     async with async_session() as session:
@@ -298,7 +299,10 @@ async def add_ingest_process_tag(
 
 @router.delete("/{id}/tags/{tag}", response_model=list[str])
 async def delete_ingest_process_tag(
-    id: int, tag: str, user_has_access: bool = Depends(has_access)
+    id: int,
+    tag: str,
+    engine: EngineDep,
+    user_has_access: bool = Depends(has_access),
 ):
     """Delete a tag from an ingest process"""
 
@@ -307,7 +311,6 @@ async def delete_ingest_process_tag(
             status_code=403, detail="User does not have access to create an object"
         )
 
-    engine = get_engine()
     async_session = get_async_session(engine)
 
     async with async_session() as session:
@@ -333,10 +336,9 @@ async def delete_ingest_process_tag(
 
 
 @router.get("/{id}/objects", response_model=list[Object.GetSecureURL])
-async def get_ingest_process_objects(id: int):
+async def get_ingest_process_objects(id: int, engine: EngineDep):
     """Get all objects for an ingestion process"""
 
-    engine = get_engine()
     async_session = get_async_session(engine)
 
     async with async_session() as session:
@@ -387,6 +389,7 @@ async def create_object(
     request: starlette.requests.Request,
     id: int,
     object: list[UploadFile],
+    engine: EngineDep,
     user_has_access: bool = Depends(has_access),
 ):
     """Create/Register a new object"""
@@ -396,7 +399,6 @@ async def create_object(
             status_code=403, detail="User does not have access to create object"
         )
 
-    engine = get_engine()
     async_session = get_async_session(engine)
 
     response_objects = []

--- a/services/api-v3/api/routes/object.py
+++ b/services/api-v3/api/routes/object.py
@@ -5,7 +5,7 @@ from functools import lru_cache
 from typing import Any
 
 import starlette.requests
-from api.database import get_async_session, get_engine
+from api.database import EngineDep, get_async_session
 from api.routes.security import has_access
 from fastapi import APIRouter, Depends, HTTPException
 from minio import Minio
@@ -175,6 +175,7 @@ def _row_to_dict(row) -> dict[str, Any]:
 
 @router.get("")
 async def list_objects(
+    engine: EngineDep,
     limit: int = 50,
     before_id: int | None = None,
     slug: str | None = None,
@@ -208,7 +209,6 @@ async def list_objects(
     ORDER BY id DESC
     LIMIT :limit
     """
-    engine = get_engine()
     async_session = get_async_session(engine)
     async with async_session() as session:
         res = await session.execute(text(sql), params)
@@ -218,8 +218,7 @@ async def list_objects(
 
 
 @router.get("/{id}")
-async def get_object(id: int):
-    engine = get_engine()
+async def get_object(id: int, engine: EngineDep):
     async_session = get_async_session(engine)
 
     async with async_session() as session:
@@ -237,6 +236,7 @@ async def get_object(id: int):
 @router.post("")
 async def create_object(
     request: starlette.requests.Request,
+    engine: EngineDep,
     user_has_access: bool = Depends(has_access),
 ):
     """
@@ -263,7 +263,6 @@ async def create_object(
     host, bucket = get_storage_host_bucket()
     s3_client = get_s3_client()
 
-    engine = get_engine()
     async_session = get_async_session(engine)
 
     created: list[dict[str, Any]] = []
@@ -328,6 +327,7 @@ async def create_object(
 async def patch_object(
     id: int,
     body: dict[str, Any],
+    engine: EngineDep,
     user_has_access: bool = Depends(has_access),
 ):
     """
@@ -345,7 +345,6 @@ async def patch_object(
     if isinstance(source, dict):
         source = json.dumps(source)
 
-    engine = get_engine()
     async_session = get_async_session(engine)
 
     async with async_session() as session:
@@ -366,6 +365,7 @@ async def patch_object(
 @router.delete("/{id}")
 async def delete_object(
     id: int,
+    engine: EngineDep,
     hard: bool = True,
     user_has_access: bool = Depends(has_access),
 ):
@@ -381,7 +381,6 @@ async def delete_object(
 
     s3_client = get_s3_client()
 
-    engine = get_engine()
     async_session = get_async_session(engine)
 
     async with async_session() as session:

--- a/services/api-v3/api/routes/object.py
+++ b/services/api-v3/api/routes/object.py
@@ -5,7 +5,7 @@ from functools import lru_cache
 from typing import Any
 
 import starlette.requests
-from api.database import EngineDep, get_async_session
+from api.database import DatabaseDep
 from api.routes.security import has_access
 from fastapi import APIRouter, Depends, HTTPException
 from minio import Minio
@@ -175,7 +175,7 @@ def _row_to_dict(row) -> dict[str, Any]:
 
 @router.get("")
 async def list_objects(
-    engine: EngineDep,
+    database: DatabaseDep,
     limit: int = 50,
     before_id: int | None = None,
     slug: str | None = None,
@@ -209,8 +209,7 @@ async def list_objects(
     ORDER BY id DESC
     LIMIT :limit
     """
-    async_session = get_async_session(engine)
-    async with async_session() as session:
+    async with database.async_session() as session:
         res = await session.execute(text(sql), params)
         items = [_row_to_dict(r) for r in res.mappings().all()]
         next_before_id = items[-1]["id"] if items else None
@@ -218,10 +217,8 @@ async def list_objects(
 
 
 @router.get("/{id}")
-async def get_object(id: int, engine: EngineDep):
-    async_session = get_async_session(engine)
-
-    async with async_session() as session:
+async def get_object(id: int, database: DatabaseDep):
+    async with database.async_session() as session:
         res = await session.execute(text(SQL_GET_OBJECT_BY_ID), dict(id=id))
         row = res.mappings().first()
 
@@ -236,7 +233,7 @@ async def get_object(id: int, engine: EngineDep):
 @router.post("")
 async def create_object(
     request: starlette.requests.Request,
-    engine: EngineDep,
+    database: DatabaseDep,
     user_has_access: bool = Depends(has_access),
 ):
     """
@@ -263,11 +260,9 @@ async def create_object(
     host, bucket = get_storage_host_bucket()
     s3_client = get_s3_client()
 
-    async_session = get_async_session(engine)
-
     created: list[dict[str, Any]] = []
 
-    async with async_session() as session:
+    async with database.async_session() as session:
         for upload in uploads:
             if not isinstance(upload, StarletteUploadFile):
                 continue
@@ -327,7 +322,7 @@ async def create_object(
 async def patch_object(
     id: int,
     body: dict[str, Any],
-    engine: EngineDep,
+    database: DatabaseDep,
     user_has_access: bool = Depends(has_access),
 ):
     """
@@ -345,9 +340,7 @@ async def patch_object(
     if isinstance(source, dict):
         source = json.dumps(source)
 
-    async_session = get_async_session(engine)
-
-    async with async_session() as session:
+    async with database.async_session() as session:
         res = await session.execute(
             text(SQL_PATCH_OBJECT),
             dict(id=id, key=key, mime_type=mime_type, source=source),
@@ -365,7 +358,7 @@ async def patch_object(
 @router.delete("/{id}")
 async def delete_object(
     id: int,
-    engine: EngineDep,
+    database: DatabaseDep,
     hard: bool = True,
     user_has_access: bool = Depends(has_access),
 ):
@@ -381,9 +374,7 @@ async def delete_object(
 
     s3_client = get_s3_client()
 
-    async_session = get_async_session(engine)
-
-    async with async_session() as session:
+    async with database.async_session() as session:
         # fetch the object row first (source of truth for bucket/key)
         res = await session.execute(text(SQL_GET_OBJECT_BY_ID), dict(id=id))
         obj = res.mappings().first()

--- a/services/api-v3/api/routes/security.py
+++ b/services/api-v3/api/routes/security.py
@@ -22,7 +22,7 @@ from fastapi.security.utils import get_authorization_scheme_param
 from jose import JWTError, jwt
 from pydantic import BaseModel
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
 from starlette.status import HTTP_401_UNAUTHORIZED
 
@@ -32,6 +32,7 @@ dotenv.load_dotenv()
 
 import api.database as db
 import api.schemas as schemas
+from api.database import DatabaseDep
 
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 1440  # 24 hours
@@ -119,9 +120,9 @@ def hash_refresh_token(raw_token: str) -> str:
     return base64.urlsafe_b64encode(digest).decode("utf-8")
 
 
-async def get_user_by_id(user_id: int, engine: AsyncEngine) -> schemas.User | None:
-    async_session = db.get_async_session(engine)
-
+async def get_user_by_id(
+    user_id: int, async_session: async_sessionmaker[AsyncSession]
+) -> schemas.User | None:
     async with async_session() as session:
         stmt = (
             select(schemas.User)
@@ -152,7 +153,7 @@ def clear_auth_cookies(response: Response):
 
 
 async def get_groups_from_header_token(
-    request: Request,
+    database: DatabaseDep,
     header_token: Annotated[HTTPAuthorizationCredentials, Depends(http_bearer)],
 ) -> int | None:
     """Get the groups from the bearer token in the header"""
@@ -163,11 +164,8 @@ async def get_groups_from_header_token(
     token_hash = bcrypt.hashpw(header_token.credentials.encode(), GROUP_TOKEN_SALT)
     token_hash_string = token_hash.decode("utf-8")
 
-    engine = db.get_engine(request)
-    async_session = db.get_async_session(engine)
-
     token = await db.get_access_token(
-        async_session=async_session, token=token_hash_string
+        async_session=database.async_sessionmaker, token=token_hash_string
     )
 
     if token is None:
@@ -176,10 +174,10 @@ async def get_groups_from_header_token(
     return token.group
 
 
-async def get_user(sub: str, engine: AsyncEngine) -> schemas.User | None:
+async def get_user(
+    sub: str, async_session: async_sessionmaker[AsyncSession]
+) -> schemas.User | None:
     """Get an existing user"""
-
-    async_session = db.get_async_session(engine)
 
     async with async_session() as session:
         stmt = (
@@ -193,11 +191,9 @@ async def get_user(sub: str, engine: AsyncEngine) -> schemas.User | None:
 
 
 async def create_user(
-    sub: str, name: str, email: str, engine: AsyncEngine
+    sub: str, name: str, email: str, async_session: async_sessionmaker[AsyncSession]
 ) -> schemas.User:
     """Create a new user"""
-
-    async_session = db.get_async_session(engine)
 
     user = schemas.User(sub=sub, name=name, email=email)
 
@@ -205,7 +201,7 @@ async def create_user(
         session.add(user)
         await session.commit()
 
-    return await get_user(sub, engine)
+    return await get_user(sub, async_session)
 
 
 async def get_user_token_from_cookie(
@@ -290,7 +286,7 @@ async def redirect_authorization(return_url: str = None):
 
 @router.get("/callback")
 async def redirect_callback(
-    code: str, engine: db.EngineDep, state: Optional[str] = None
+    code: str, database: DatabaseDep, state: Optional[str] = None
 ):
     """Exchange the code for a token and redirect to the state URL"""
 
@@ -334,7 +330,7 @@ async def redirect_callback(
 
             user_data = await user_response.json()
             # need to look up the user_id and return it in the jwt
-            user = await get_user(user_data["sub"], engine)
+            user = await get_user(user_data["sub"], database.async_sessionmaker)
 
             if user is None:
 
@@ -349,7 +345,7 @@ async def redirect_callback(
                     user_data["sub"],
                     f"{given_name} {family_name}",
                     user_data.get("email", ""),
-                    engine,
+                    database.async_sessionmaker,
                 )
 
             # Check if the user is in the admin group to set the appropriate database role
@@ -433,6 +429,7 @@ async def redirect_callback(
 async def refresh_token(
     request: Request,
     response: Response,
+    database: DatabaseDep,
     refresh_token: str | None = Cookie(default=None, alias=refresh_token_key),
 ):
     if not refresh_token:
@@ -459,7 +456,7 @@ async def refresh_token(
         raise HTTPException(status_code=401, detail="Refresh token invalid")
 
     # verifying the user_id and group_id
-    user = await get_user_by_id(int(user_id), db.get_engine(request))
+    user = await get_user_by_id(int(user_id), database.async_sessionmaker)
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
     names = {g.name for g in user.groups}
@@ -492,7 +489,7 @@ async def refresh_token(
 @router.post("/token", response_model=AccessToken)
 async def create_group_token(
     group_token_request: GroupTokenRequest,
-    engine: db.EngineDep,
+    database: DatabaseDep,
     user_token: TokenData = Depends(get_user_token_from_cookie),
 ):
     """Get an access token for the current user"""
@@ -512,7 +509,7 @@ async def create_group_token(
     )
 
     await db.insert_group_api_token(
-        engine=engine,
+        engine=database.async_engine,
         token_hash_string=token_hash_string,
         group_id=group_token_request.group_id,
         expiration_dt=datetime.fromtimestamp(
@@ -538,7 +535,7 @@ async def get_security_groups(groups: list[int] = Depends(get_groups)):
 
 @router.get("/me")
 async def read_users_me(
-    engine: db.EngineDep,
+    database: DatabaseDep,
     user_token_data: TokenData = Depends(get_user_token_from_cookie),
 ):
     """Return JWT content"""
@@ -546,9 +543,7 @@ async def read_users_me(
     if user_token_data is None:
         raise HTTPException(status_code=401, detail="User not found")
 
-    async_session = db.get_async_session(engine)
-
-    async with async_session() as session:
+    async with database.async_session() as session:
         user_stmt = (
             select(schemas.User)
             .options(selectinload(schemas.User.groups))

--- a/services/api-v3/api/routes/security.py
+++ b/services/api-v3/api/routes/security.py
@@ -22,6 +22,7 @@ from fastapi.security.utils import get_authorization_scheme_param
 from jose import JWTError, jwt
 from pydantic import BaseModel
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlalchemy.orm import selectinload
 from starlette.status import HTTP_401_UNAUTHORIZED
 
@@ -118,8 +119,7 @@ def hash_refresh_token(raw_token: str) -> str:
     return base64.urlsafe_b64encode(digest).decode("utf-8")
 
 
-async def get_user_by_id(user_id: int) -> schemas.User | None:
-    engine = db.get_engine()
+async def get_user_by_id(user_id: int, engine: AsyncEngine) -> schemas.User | None:
     async_session = db.get_async_session(engine)
 
     async with async_session() as session:
@@ -152,7 +152,8 @@ def clear_auth_cookies(response: Response):
 
 
 async def get_groups_from_header_token(
-    header_token: Annotated[HTTPAuthorizationCredentials, Depends(http_bearer)]
+    request: Request,
+    header_token: Annotated[HTTPAuthorizationCredentials, Depends(http_bearer)],
 ) -> int | None:
     """Get the groups from the bearer token in the header"""
 
@@ -162,7 +163,7 @@ async def get_groups_from_header_token(
     token_hash = bcrypt.hashpw(header_token.credentials.encode(), GROUP_TOKEN_SALT)
     token_hash_string = token_hash.decode("utf-8")
 
-    engine = db.get_engine()
+    engine = db.get_engine(request)
     async_session = db.get_async_session(engine)
 
     token = await db.get_access_token(
@@ -175,10 +176,9 @@ async def get_groups_from_header_token(
     return token.group
 
 
-async def get_user(sub: str) -> schemas.User | None:
+async def get_user(sub: str, engine: AsyncEngine) -> schemas.User | None:
     """Get an existing user"""
 
-    engine = db.get_engine()
     async_session = db.get_async_session(engine)
 
     async with async_session() as session:
@@ -192,10 +192,11 @@ async def get_user(sub: str) -> schemas.User | None:
     return user
 
 
-async def create_user(sub: str, name: str, email: str) -> schemas.User:
+async def create_user(
+    sub: str, name: str, email: str, engine: AsyncEngine
+) -> schemas.User:
     """Create a new user"""
 
-    engine = db.get_engine()
     async_session = db.get_async_session(engine)
 
     user = schemas.User(sub=sub, name=name, email=email)
@@ -204,7 +205,7 @@ async def create_user(sub: str, name: str, email: str) -> schemas.User:
         session.add(user)
         await session.commit()
 
-    return await get_user(sub)
+    return await get_user(sub, engine)
 
 
 async def get_user_token_from_cookie(
@@ -288,7 +289,9 @@ async def redirect_authorization(return_url: str = None):
 
 
 @router.get("/callback")
-async def redirect_callback(code: str, state: Optional[str] = None):
+async def redirect_callback(
+    code: str, engine: db.EngineDep, state: Optional[str] = None
+):
     """Exchange the code for a token and redirect to the state URL"""
 
     uri = os.environ["REDIRECT_URI_ENV"]
@@ -331,7 +334,7 @@ async def redirect_callback(code: str, state: Optional[str] = None):
 
             user_data = await user_response.json()
             # need to look up the user_id and return it in the jwt
-            user = await get_user(user_data["sub"])
+            user = await get_user(user_data["sub"], engine)
 
             if user is None:
 
@@ -346,6 +349,7 @@ async def redirect_callback(code: str, state: Optional[str] = None):
                     user_data["sub"],
                     f"{given_name} {family_name}",
                     user_data.get("email", ""),
+                    engine,
                 )
 
             # Check if the user is in the admin group to set the appropriate database role
@@ -455,7 +459,7 @@ async def refresh_token(
         raise HTTPException(status_code=401, detail="Refresh token invalid")
 
     # verifying the user_id and group_id
-    user = await get_user_by_id(int(user_id))
+    user = await get_user_by_id(int(user_id), db.get_engine(request))
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
     names = {g.name for g in user.groups}
@@ -488,6 +492,7 @@ async def refresh_token(
 @router.post("/token", response_model=AccessToken)
 async def create_group_token(
     group_token_request: GroupTokenRequest,
+    engine: db.EngineDep,
     user_token: TokenData = Depends(get_user_token_from_cookie),
 ):
     """Get an access token for the current user"""
@@ -498,8 +503,6 @@ async def create_group_token(
             detail=f"User cannot create tokens for group {group_token_request.group_id}",
         )
 
-    engine = db.get_engine()
-
     token = "".join(
         secrets.choice(string.ascii_letters + string.digits)
         for i in range(GROUP_TOKEN_LENGTH)
@@ -509,7 +512,7 @@ async def create_group_token(
     )
 
     await db.insert_group_api_token(
-        engine=db.get_engine(),
+        engine=engine,
         token_hash_string=token_hash_string,
         group_id=group_token_request.group_id,
         expiration_dt=datetime.fromtimestamp(
@@ -535,6 +538,7 @@ async def get_security_groups(groups: list[int] = Depends(get_groups)):
 
 @router.get("/me")
 async def read_users_me(
+    engine: db.EngineDep,
     user_token_data: TokenData = Depends(get_user_token_from_cookie),
 ):
     """Return JWT content"""
@@ -542,7 +546,6 @@ async def read_users_me(
     if user_token_data is None:
         raise HTTPException(status_code=401, detail="User not found")
 
-    engine = db.get_engine()
     async_session = db.get_async_session(engine)
 
     async with async_session() as session:

--- a/services/api-v3/api/routes/sources.py
+++ b/services/api-v3/api/routes/sources.py
@@ -16,8 +16,7 @@ import api.database as db
 import api.models.source as Sources
 import api.schemas as schemas
 from api.database import (
-    EngineDep,
-    get_async_session,
+    DatabaseDep,
     get_table,
     patch_sources_sub_table,
     select_sources_sub_table,
@@ -43,13 +42,12 @@ router = APIRouter(
 @router.get("")
 async def get_sources(
     response: Response,
-    engine: EngineDep,
+    database: DatabaseDep,
     page: int = 0,
     page_size: int = 100,
     include_geom: bool = False,
 ) -> List[Sources.Get]:
-    async_session = get_async_session(engine)
-    sources = await db.get_sources(async_session, page, page_size)
+    sources = await db.get_sources(database.async_sessionmaker, page, page_size)
 
     # Delete the geom if not required
     if not include_geom:
@@ -66,12 +64,10 @@ async def get_sources(
 
 
 @router.get("/{source_id}")
-async def get_source(source_id: int, engine: EngineDep) -> Sources.Get:
+async def get_source(source_id: int, database: DatabaseDep) -> Sources.Get:
     """Get a single object"""
 
-    async_session = get_async_session(engine)
-
-    async with async_session() as session:
+    async with database.async_session() as session:
         select_stmt = select(
             *[
                 c
@@ -94,7 +90,7 @@ async def get_source(source_id: int, engine: EngineDep) -> Sources.Get:
 async def patch_source(
     source_id: int,
     source: Sources.Patch,
-    engine: EngineDep,
+    database: DatabaseDep,
     user_has_access: bool = Depends(has_access),
 ) -> Sources.Get:
     """Patch a source"""
@@ -104,9 +100,7 @@ async def patch_source(
             status_code=401, detail="User does not have access to patch object"
         )
 
-    async_session = get_async_session(engine)
-
-    async with async_session() as session:
+    async with database.async_session() as session:
         update_stmt = (
             update(schemas.Sources)
             .where(schemas.Sources.source_id == source_id)
@@ -124,7 +118,7 @@ async def patch_source(
 @router.post("")
 async def post_source(
     source: Sources.Post,
-    engine: EngineDep,
+    database: DatabaseDep,
     user_has_access: bool = Depends(has_access),
 ) -> Sources.Get:
     """Post a source"""
@@ -134,13 +128,11 @@ async def post_source(
             status_code=401, detail="User does not have access to post object"
         )
 
-    async_session = get_async_session(engine)
-
     if source.slug is None:
         source.slug = re.sub(r"\W", "_", slugify(source.name, max_length=30))
     source.primary_table = source.slug + "_polygons"
 
-    async with async_session() as session:
+    async with database.async_session() as session:
         insert_stmt = (
             insert(schemas.Sources)
             .values(**source.model_dump())
@@ -154,10 +146,10 @@ async def post_source(
 
 
 @router.get("/{table_id}/geometries")
-async def get_sub_sources_geometries(table_id: int, engine: EngineDep):
+async def get_sub_sources_geometries(table_id: int, database: DatabaseDep):
     result = {}
 
-    async with engine.begin() as conn:
+    async with database.async_connection() as conn:
 
         for geometry in ["polygons", "lines", "points"]:
 
@@ -222,13 +214,13 @@ async def get_sub_sources_helper(
 async def get_sub_sources(
     response: Response,
     request: starlette.requests.Request,
-    engine: EngineDep,
+    database: DatabaseDep,
     table_id: int,
     page: int = 0,
     page_size: int = 100,
 ):
     return await get_sub_sources_helper(
-        response, request, engine, table_id, "polygons", page, page_size
+        response, request, database.async_engine, table_id, "polygons", page, page_size
     )
 
 
@@ -236,13 +228,13 @@ async def get_sub_sources(
 async def get_sub_sources(
     response: Response,
     request: starlette.requests.Request,
-    engine: EngineDep,
+    database: DatabaseDep,
     table_id: int,
     page: int = 0,
     page_size: int = 100,
 ):
     return await get_sub_sources_helper(
-        response, request, engine, table_id, "points", page, page_size
+        response, request, database.async_engine, table_id, "points", page, page_size
     )
 
 
@@ -250,13 +242,13 @@ async def get_sub_sources(
 async def get_sub_sources(
     response: Response,
     request: starlette.requests.Request,
-    engine: EngineDep,
+    database: DatabaseDep,
     table_id: int,
     page: int = 0,
     page_size: int = 100,
 ):
     return await get_sub_sources_helper(
-        response, request, engine, table_id, "lines", page, page_size
+        response, request, database.async_engine, table_id, "lines", page, page_size
     )
 
 
@@ -266,7 +258,7 @@ async def patch_sub_sources(
     table_id: int,
     geometry_type: Literal["polygons", "lines", "points"],
     updates: Union[PolygonRequestModel, LineStringModel, PointModel],
-    engine: EngineDep,
+    database: DatabaseDep,
     user_has_access: bool = Depends(has_access),
 ) -> List[Union[PolygonResponseModel, LineStringModel, PointModel]]:
     if not user_has_access:
@@ -276,7 +268,7 @@ async def patch_sub_sources(
 
     try:
         result = await patch_sources_sub_table(
-            engine=engine,
+            engine=database.async_engine,
             table_id=table_id,
             geometry_type=geometry_type,
             update_values=updates.model_dump(exclude_none=True),
@@ -310,7 +302,7 @@ async def patch_sub_sources(
     table_id: int,
     geometry_type: Literal["polygons", "lines", "points"],
     copy_column: CopyColumnRequest,
-    engine: EngineDep,
+    database: DatabaseDep,
     user_has_access: bool = Depends(has_access),
 ):
     if not user_has_access:
@@ -320,7 +312,7 @@ async def patch_sub_sources(
 
     try:
         result = await db.patch_sources_sub_table_set_columns_equal(
-            engine=engine,
+            engine=database.async_engine,
             table_id=table_id,
             geometry_type=geometry_type,
             source_column=copy_column.source_column,

--- a/services/api-v3/api/routes/sources.py
+++ b/services/api-v3/api/routes/sources.py
@@ -8,16 +8,16 @@ from fastapi import APIRouter, Depends, HTTPException, Response, status
 from slugify import slugify
 from sqlalchemy import func, insert, select, update
 from sqlalchemy.exc import NoResultFound, NoSuchTableError
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 dotenv.load_dotenv()
 
 import api.database as db
 import api.models.source as Sources
-import api.routes.security
 import api.schemas as schemas
 from api.database import (
+    EngineDep,
     get_async_session,
-    get_engine,
     get_table,
     patch_sources_sub_table,
     select_sources_sub_table,
@@ -42,9 +42,13 @@ router = APIRouter(
 
 @router.get("")
 async def get_sources(
-    response: Response, page: int = 0, page_size: int = 100, include_geom: bool = False
+    response: Response,
+    engine: EngineDep,
+    page: int = 0,
+    page_size: int = 100,
+    include_geom: bool = False,
 ) -> List[Sources.Get]:
-    async_session = get_async_session(get_engine())
+    async_session = get_async_session(engine)
     sources = await db.get_sources(async_session, page, page_size)
 
     # Delete the geom if not required
@@ -62,10 +66,9 @@ async def get_sources(
 
 
 @router.get("/{source_id}")
-async def get_source(source_id: int) -> Sources.Get:
+async def get_source(source_id: int, engine: EngineDep) -> Sources.Get:
     """Get a single object"""
 
-    engine = get_engine()
     async_session = get_async_session(engine)
 
     async with async_session() as session:
@@ -89,7 +92,10 @@ async def get_source(source_id: int) -> Sources.Get:
 
 @router.patch("/{source_id}")
 async def patch_source(
-    source_id: int, source: Sources.Patch, user_has_access: bool = Depends(has_access)
+    source_id: int,
+    source: Sources.Patch,
+    engine: EngineDep,
+    user_has_access: bool = Depends(has_access),
 ) -> Sources.Get:
     """Patch a source"""
 
@@ -98,7 +104,6 @@ async def patch_source(
             status_code=401, detail="User does not have access to patch object"
         )
 
-    engine = get_engine()
     async_session = get_async_session(engine)
 
     async with async_session() as session:
@@ -118,7 +123,9 @@ async def patch_source(
 
 @router.post("")
 async def post_source(
-    source: Sources.Post, user_has_access: bool = Depends(has_access)
+    source: Sources.Post,
+    engine: EngineDep,
+    user_has_access: bool = Depends(has_access),
 ) -> Sources.Get:
     """Post a source"""
 
@@ -127,7 +134,6 @@ async def post_source(
             status_code=401, detail="User does not have access to post object"
         )
 
-    engine = get_engine()
     async_session = get_async_session(engine)
 
     if source.slug is None:
@@ -148,10 +154,9 @@ async def post_source(
 
 
 @router.get("/{table_id}/geometries")
-async def get_sub_sources_geometries(table_id: int):
+async def get_sub_sources_geometries(table_id: int, engine: EngineDep):
     result = {}
 
-    engine = get_engine()
     async with engine.begin() as conn:
 
         for geometry in ["polygons", "lines", "points"]:
@@ -169,6 +174,7 @@ async def get_sub_sources_geometries(table_id: int):
 async def get_sub_sources_helper(
     response: Response,
     request: starlette.requests.Request,
+    engine: AsyncEngine,
     table_id: int,
     geometry_type: Literal["polygons", "lines", "points"],
     page: int = 0,
@@ -183,7 +189,7 @@ async def get_sub_sources_helper(
             )
         ]
         result = await select_sources_sub_table(
-            engine=get_engine(),
+            engine=engine,
             table_id=table_id,
             geometry_type=geometry_type,
             page=page,
@@ -194,7 +200,7 @@ async def get_sub_sources_helper(
         # Add metadata to the response
         response.headers["X-Total-Count"] = str(
             await db.get_sources_sub_table_count(
-                engine=get_engine(),
+                engine=engine,
                 query_params=filter_query_params,
                 table_id=table_id,
                 geometry_type=geometry_type,
@@ -216,12 +222,13 @@ async def get_sub_sources_helper(
 async def get_sub_sources(
     response: Response,
     request: starlette.requests.Request,
+    engine: EngineDep,
     table_id: int,
     page: int = 0,
     page_size: int = 100,
 ):
     return await get_sub_sources_helper(
-        response, request, table_id, "polygons", page, page_size
+        response, request, engine, table_id, "polygons", page, page_size
     )
 
 
@@ -229,12 +236,13 @@ async def get_sub_sources(
 async def get_sub_sources(
     response: Response,
     request: starlette.requests.Request,
+    engine: EngineDep,
     table_id: int,
     page: int = 0,
     page_size: int = 100,
 ):
     return await get_sub_sources_helper(
-        response, request, table_id, "points", page, page_size
+        response, request, engine, table_id, "points", page, page_size
     )
 
 
@@ -242,12 +250,13 @@ async def get_sub_sources(
 async def get_sub_sources(
     response: Response,
     request: starlette.requests.Request,
+    engine: EngineDep,
     table_id: int,
     page: int = 0,
     page_size: int = 100,
 ):
     return await get_sub_sources_helper(
-        response, request, table_id, "lines", page, page_size
+        response, request, engine, table_id, "lines", page, page_size
     )
 
 
@@ -257,6 +266,7 @@ async def patch_sub_sources(
     table_id: int,
     geometry_type: Literal["polygons", "lines", "points"],
     updates: Union[PolygonRequestModel, LineStringModel, PointModel],
+    engine: EngineDep,
     user_has_access: bool = Depends(has_access),
 ) -> List[Union[PolygonResponseModel, LineStringModel, PointModel]]:
     if not user_has_access:
@@ -266,7 +276,7 @@ async def patch_sub_sources(
 
     try:
         result = await patch_sources_sub_table(
-            engine=get_engine(),
+            engine=engine,
             table_id=table_id,
             geometry_type=geometry_type,
             update_values=updates.model_dump(exclude_none=True),
@@ -300,6 +310,7 @@ async def patch_sub_sources(
     table_id: int,
     geometry_type: Literal["polygons", "lines", "points"],
     copy_column: CopyColumnRequest,
+    engine: EngineDep,
     user_has_access: bool = Depends(has_access),
 ):
     if not user_has_access:
@@ -309,7 +320,7 @@ async def patch_sub_sources(
 
     try:
         result = await db.patch_sources_sub_table_set_columns_equal(
-            engine=get_engine(),
+            engine=engine,
             table_id=table_id,
             geometry_type=geometry_type,
             source_column=copy_column.source_column,

--- a/services/api-v3/api/tests/test_database.py
+++ b/services/api-v3/api/tests/test_database.py
@@ -15,7 +15,7 @@ load_dotenv()
 
 import api.database as db
 from api.app import app
-from api.database import connect_engine, dispose_engine, get_engine
+from api.database import build_async_engine
 from api.models.geometries import PolygonModel
 
 # Define some testing values
@@ -43,9 +43,9 @@ def api_client() -> TestClient:
 
 @pytest.fixture
 async def engine() -> AsyncEngine:
-    await connect_engine()
-    yield get_engine()
-    await dispose_engine()
+    _engine = build_async_engine()
+    yield _engine
+    await _engine.dispose()
 
 
 @pytest.fixture
@@ -64,7 +64,8 @@ class TestUtils:
 
     @pytest.mark.asyncio
     async def test_source_id_to_slug(self, engine: AsyncEngine):
-        slug = await db.source_id_to_slug(engine, TEST_SOURCE_TABLE.source_id)
+        async with engine.begin() as conn:
+            slug = await db.source_id_to_slug(conn, TEST_SOURCE_TABLE.source_id)
         assert slug == TEST_SOURCE_TABLE.slug
 
 

--- a/services/api-v3/api/tests/test_database.py
+++ b/services/api-v3/api/tests/test_database.py
@@ -15,7 +15,7 @@ load_dotenv()
 
 import api.database as db
 from api.app import app
-from api.database import build_async_engine
+from api.database import AppDatabase, get_db_url
 from api.models.geometries import PolygonModel
 
 # Define some testing values
@@ -43,9 +43,9 @@ def api_client() -> TestClient:
 
 @pytest.fixture
 async def engine() -> AsyncEngine:
-    _engine = build_async_engine()
-    yield _engine
-    await _engine.dispose()
+    database = AppDatabase(get_db_url())
+    yield database.async_engine
+    await database.dispose()
 
 
 @pytest.fixture


### PR DESCRIPTION
There were several bugs with API v3's database lifecycle handling.

This unifies the engine/session management in one `AppDatabase` class and injectable request dependency that handles both async and sync database pools. This hopefully will standardize database access patterns across the app and make any future bug fixes or evolution of pool connectivity issues easier to diagnose.