### PR TITLE
Refactor jwt

### DIFF
--- a/local-root/Caddyfile
+++ b/local-root/Caddyfile
@@ -153,9 +153,22 @@ localhost, macrostrat.local {
 }
 
 dev.macrostrat.local {
-    # Proxy to the locally running frontend application, if running
     tls internal
-    reverse_proxy host.docker.internal:3000
+
+    handle_path /api/v2/* {
+        reverse_proxy api_v2:5000
+    }
+    handle_path /api/v3/* {
+        reverse_proxy api_v3:80
+    }
+
+    import schema-proxy /api/v3/macrostrat/pg macrostrat_api
+    import schema-proxy /api/v3/map-ingestion/pg map_ingestion_api
+    import schema-proxy /api/pg macrostrat_api
+
+    handle {
+        reverse_proxy host.docker.internal:3000
+    }
 }
 
 dev.macrostrat.local:24678 {

--- a/local-root/Makefile
+++ b/local-root/Makefile
@@ -17,7 +17,7 @@ start-database:
 	macrostrat compose up -d database storage
 
 start-gateway:
-	macrostrat up gateway
+	macrostrat up --force-recreate gateway
 
 build-restart:
 	macrostrat up --force-recreate api_v3

--- a/py-modules/cli/macrostrat/cli/entrypoint.py
+++ b/py-modules/cli/macrostrat/cli/entrypoint.py
@@ -29,7 +29,7 @@ __here__ = Path(__file__).parent
 fixtures_dir = __here__ / "fixtures"
 
 app.warnings = []
-app.info = []
+app.info_messages = []
 
 install(show_locals=False)
 
@@ -62,7 +62,7 @@ help_text = f"""[bold]Macrostrat[/] control interface
 
 """
 
-app.info.append(f"Active environment: [bold cyan]{_env_text}[/]")
+app.info_messages.append(f"Active environment: [bold cyan]{_env_text}[/]")
 
 if not settings.pg_database:
     app.warnings.append("No database URL found in settings")
@@ -93,8 +93,8 @@ except SubsystemLoadError as err:
 # existing commands.
 run_user_command_if_provided(*settings.script_dirs)
 
-if app.info:
-    help_text += "\n".join([f"- {w}" for w in app.info]) + "\n"
+if app.info_messages:
+    help_text += "\n".join([f"- {w}" for w in app.info_messages]) + "\n"
 
 # Now, we render the warnings in the CLI help text
 if app.warnings:

--- a/schema/core/0002-macrostrat_auth.sql
+++ b/schema/core/0002-macrostrat_auth.sql
@@ -68,12 +68,13 @@ ALTER TABLE macrostrat_auth.token_id_seq OWNER TO macrostrat;
 ALTER SEQUENCE macrostrat_auth.token_id_seq OWNED BY macrostrat_auth.token.id;
 
 CREATE TABLE macrostrat_auth."user" (
-    id integer NOT NULL,
-    sub character varying(255) NOT NULL,
-    name character varying(255),
-    email character varying(255),
-    created_on timestamp with time zone DEFAULT now() NOT NULL,
-    updated_on timestamp with time zone DEFAULT now() NOT NULL
+    id           serial primary key,
+    sub          varchar(255) not null unique,
+    name         varchar(255),
+    email        varchar(255),
+    display_name varchar(255),
+    created_on   timestamp with time zone default now() not null,
+    updated_on   timestamp with time zone default now() not null,
 );
 ALTER TABLE macrostrat_auth."user" OWNER TO macrostrat;
 

--- a/schema/core/0002-macrostrat_auth.sql
+++ b/schema/core/0002-macrostrat_auth.sql
@@ -74,7 +74,7 @@ CREATE TABLE macrostrat_auth."user" (
     email        varchar(255),
     display_name varchar(255),
     created_on   timestamp with time zone default now() not null,
-    updated_on   timestamp with time zone default now() not null,
+    updated_on   timestamp with time zone default now() not null
 );
 ALTER TABLE macrostrat_auth."user" OWNER TO macrostrat;
 

--- a/services/api-v3/api/routes/security.py
+++ b/services/api-v3/api/routes/security.py
@@ -55,7 +55,7 @@ class Token(BaseModel):
 
 class TokenData(BaseModel):
     sub: str
-    groups: list[int] = []
+    role: str | None = None
 
 
 class User(BaseModel):
@@ -118,18 +118,6 @@ def hash_refresh_token(raw_token: str) -> str:
     key = os.environ["SECRET_KEY"].encode("utf-8")
     digest = hmac.new(key, raw_token.encode("utf-8"), hashlib.sha256).digest()
     return base64.urlsafe_b64encode(digest).decode("utf-8")
-
-
-async def get_user_by_id(
-    user_id: int, async_session: async_sessionmaker[AsyncSession]
-) -> schemas.User | None:
-    async with async_session() as session:
-        stmt = (
-            select(schemas.User)
-            .options(selectinload(schemas.User.groups))
-            .where(schemas.User.id == user_id)
-        )
-        return await session.scalar(stmt)
 
 
 def parse_redirect_uri():
@@ -220,8 +208,8 @@ async def get_user_token_from_cookie(
             algorithms=[os.environ["JWT_ENCRYPTION_ALGORITHM"]],
         )
         sub: str = payload.get("sub")
-        groups = payload.get("groups", [])
-        token_data = TokenData(sub=sub, groups=groups)
+        role: str | None = payload.get("role")
+        token_data = TokenData(sub=sub, role=role)
     except JWTError as e:
         return None
 
@@ -229,14 +217,17 @@ async def get_user_token_from_cookie(
 
 
 async def get_groups(
+    database: DatabaseDep,
     user_token_data: TokenData | None = Depends(get_user_token_from_cookie),
     header_token: int | None = Depends(get_groups_from_header_token),
 ) -> list[int]:
-    """Get the groups from both the cookies and header"""
+    """Get the user's group ids from the database (via the JWT `sub`) and header"""
 
     groups = []
     if user_token_data is not None:
-        groups = user_token_data.groups
+        user = await get_user(user_token_data.sub, database.async_sessionmaker)
+        if user is not None:
+            groups = [g.id for g in user.groups]
 
     if header_token is not None:
         groups.append(header_token)
@@ -244,9 +235,14 @@ async def get_groups(
     return groups
 
 
-async def has_access(groups: list[int] = Depends(get_groups)) -> bool:
-    """Check if the user has access to the group"""
-    return 1 in groups
+async def has_access(
+    user_token_data: TokenData | None = Depends(get_user_token_from_cookie),
+    header_token: int | None = Depends(get_groups_from_header_token),
+) -> bool:
+    """Check for admin access via the JWT role or a group-1 API token"""
+    if user_token_data is not None and user_token_data.role == "web_admin":
+        return True
+    return header_token == 1
 
 
 def create_access_token(data: dict, expires_delta: timedelta | None = None):
@@ -329,7 +325,7 @@ async def redirect_callback(
                 )
 
             user_data = await user_response.json()
-            # need to look up the user_id and return it in the jwt
+            # look up the user by their OIDC subject to compute their role
             user = await get_user(user_data["sub"], database.async_sessionmaker)
 
             if user is None:
@@ -358,14 +354,10 @@ async def redirect_callback(
             )
 
             # validate jwt https://dev.macrostrat.org/dev/me
-            # TODO remove the groups and sub and add the user_name
             access_token = create_access_token(
                 data={
                     "sub": user.sub,
                     "role": role,  # For PostgREST
-                    # ensure user_id is correctly being returned
-                    "user_id": user.id,
-                    "groups": list(ids),
                 }
             )
 
@@ -403,7 +395,6 @@ async def redirect_callback(
             # TODO remove the token type
             refresh_jwt = jwt.encode(
                 {
-                    "user_id": user.id,
                     "sub": user.sub,
                     "type": "refresh",
                     "exp": datetime.utcnow()
@@ -450,13 +441,13 @@ async def refresh_token(
         clear_auth_cookies(response)
         raise HTTPException(status_code=401, detail="Refresh token invalid")
 
-    user_id = payload.get("user_id")
-    if not user_id:
+    sub = payload.get("sub")
+    if not sub:
         clear_auth_cookies(response)
         raise HTTPException(status_code=401, detail="Refresh token invalid")
 
-    # verifying the user_id and group_id
-    user = await get_user_by_id(int(user_id), database.async_sessionmaker)
+    # verifying the user via the subject claim
+    user = await get_user(sub, database.async_sessionmaker)
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
     names = {g.name for g in user.groups}
@@ -467,9 +458,8 @@ async def refresh_token(
         else "web_user"
     )
     # setting new access cookie
-    # TODO can remove groups, sub. add user_name.
     access_token = create_access_token(
-        data={"sub": user.sub, "role": role, "user_id": user.id, "groups": list(ids)}
+        data={"sub": user.sub, "role": role}
     )
 
     parsed_url, hostname, cookie_domain, secure = parse_redirect_uri()
@@ -494,7 +484,12 @@ async def create_group_token(
 ):
     """Get an access token for the current user"""
 
-    if group_token_request.group_id not in user_token.groups:
+    if user_token is None:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    user = await get_user(user_token.sub, database.async_sessionmaker)
+    group_ids = {g.id for g in user.groups} if user is not None else set()
+    if group_token_request.group_id not in group_ids:
         raise HTTPException(
             status_code=401,
             detail=f"User cannot create tokens for group {group_token_request.group_id}",

--- a/services/api-v3/api/routes/security.py
+++ b/services/api-v3/api/routes/security.py
@@ -178,12 +178,19 @@ async def get_user(
     return user
 
 
+def get_display_name(name: str) -> str:
+    """Parses first name in the name string coming from orcid"""
+    return name.split(" ")[0] if name else ""
+
+
 async def create_user(
     sub: str, name: str, email: str, async_session: async_sessionmaker[AsyncSession]
 ) -> schemas.User:
     """Create a new user"""
 
-    user = schemas.User(sub=sub, name=name, email=email)
+    user = schemas.User(
+        sub=sub, name=name, display_name=get_display_name(name), email=email
+    )
 
     async with async_session() as session:
         session.add(user)
@@ -339,7 +346,7 @@ async def redirect_callback(
 
                 user = await create_user(
                     user_data["sub"],
-                    f"{given_name} {family_name}",
+                    f"{given_name} {family_name}".strip(),
                     user_data.get("email", ""),
                     database.async_sessionmaker,
                 )
@@ -358,6 +365,7 @@ async def redirect_callback(
                 data={
                     "sub": user.sub,
                     "role": role,  # For PostgREST
+                    "name": user.display_name,
                 }
             )
 
@@ -397,6 +405,7 @@ async def redirect_callback(
                 {
                     "sub": user.sub,
                     "type": "refresh",
+                    "name": user.display_name,
                     "exp": datetime.utcnow()
                     + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS),
                 },
@@ -459,7 +468,7 @@ async def refresh_token(
     )
     # setting new access cookie
     access_token = create_access_token(
-        data={"sub": user.sub, "role": role}
+        data={"sub": user.sub, "role": role, "name": user.display_name}
     )
 
     parsed_url, hostname, cookie_domain, secure = parse_redirect_uri()
@@ -552,8 +561,7 @@ async def read_users_me(
             "sub": user.sub,
             "email": user.email,
             "id": user.id,
-            "name": user.name,
+            "display_name": user.display_name,
             "created_on": user.created_on,
             "updated_on": user.updated_on,
-            "groups": [{"name": g.name, "id": g.id} for g in user.groups],
         }

--- a/services/api-v3/api/schemas.py
+++ b/services/api-v3/api/schemas.py
@@ -85,6 +85,7 @@ class User(Base):
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     sub: Mapped[str] = mapped_column(VARCHAR(255))
     name: Mapped[str] = mapped_column(VARCHAR(255))
+    display_name: Mapped[str] = mapped_column(VARCHAR(255), nullable=True)
     email: Mapped[str] = mapped_column(VARCHAR(255))
     groups: Mapped[List[Group]] = relationship(
         secondary="macrostrat_auth.group_members", lazy="joined", back_populates="users"


### PR DESCRIPTION
api-v3

- Removed groups and user_id from JWTs.
- JWTs now contain only sub, role, name, and exp.
- Group membership is now retrieved from the database.
- Added display_name to users and exposed it as the JWT name.
- Updated authorization checks to use role.
- Fixed macrostrat up crashing because app.info conflicted with app_frame.

Web

- Updated route guards to use user.role instead of user.groups.
- Removed unused group-based logic.
- Updated @macrostrat/form-components to 1.0.10 and cleaned up duplicate lockfile entries.