### PR TITLE
Age and location tolerance

### DIFF
--- a/py-modules/match-utils/macrostrat/match_utils/__init__.py
+++ b/py-modules/match-utils/macrostrat/match_utils/__init__.py
@@ -23,7 +23,7 @@ _column_unit_index = {}
 # north-south at any latitude, but only 0.86 km east-west at 39 degrees and 0.29 km
 # at 75 degrees. 1.11 km preserves the north-south reach exactly and makes the
 # east-west reach match it instead of narrowing toward the poles.
-DEFAULT_SPATIAL_TOLERANCE_KM = 1.11
+DEFAULT_LOCATION_TOLERANCE_KM = 1.11
 
 MATCH_STRAT_NAMES_INFO = {
     "success": {
@@ -74,15 +74,15 @@ MATCH_STRAT_NAMES_INFO = {
                 "age_tolerance": "number, allowable gap in millions of years between the query "
                 "age window and a unit's age range. Default 0 (strict overlap). A unit falling "
                 "short of overlapping the window by no more than this amount is still matched, "
-                "and reported with temporal_basis='adjacent interval'. Requires an age window "
+                "and reported with age_basis='adjacent interval'. Requires an age window "
                 "to widen: supply interval, or both bounds via b_age/b_interval and "
                 "t_age/t_interval, otherwise the request is rejected with a 422. Does not "
                 "affect priority.",
-                "spatial_tolerance": "number, how far in kilometres an adjacent column may be "
+                "location_tolerance": "number, how far in kilometres an adjacent column may be "
                 "from the column containing the query location and still contribute matches. "
                 "Default 1.11, which preserves the reach of the 0.01-degree buffer it replaced. "
                 "Matches from outside the containing column are reported with "
-                "spatial_basis='adjacent column'. Columns tessellate, so neighbours share "
+                "location_basis='adjacent column'. Columns tessellate, so neighbours share "
                 "edges and lie at distance 0 — a tolerance of 0 still admits every "
                 "edge-sharing column, and only larger values reach columns that do not touch.",
                 "identifier": "string or integer, optional identifier to tag a query (e.g. a "
@@ -146,9 +146,9 @@ MATCH_STRAT_NAMES_INFO = {
                 "depth": "integer, hierarchy traversal depth (0=direct, negative=parent/rank-up, positive=child/rank-down)",
                 "name_basis": "string, matching strategy that produced this result. "
                 "One of: exact | concept | rank-up | rank-down | synonym",
-                "spatial_basis": "string, spatial relationship of the match. "
+                "location_basis": "string, spatial relationship of the match. "
                 "One of: containing column | adjacent column",
-                "temporal_basis": "string or null, temporal relationship of the match. "
+                "age_basis": "string or null, temporal relationship of the match. "
                 "One of: containing interval | adjacent interval. 'containing interval' means "
                 "the unit's age range overlaps the query age window; 'adjacent interval' means "
                 "it did not overlap but fell within age_tolerance of it. With an age window but "
@@ -288,15 +288,15 @@ def get_column_units(
     conn,
     col_id,
     types: list[MatchType] = None,
-    spatial_tolerance: float = DEFAULT_SPATIAL_TOLERANCE_KM,
+    location_tolerance: float = DEFAULT_LOCATION_TOLERANCE_KM,
 ):
     """
     Get a unit that matches a given stratigraphic name
 
-    `spatial_tolerance` is in kilometers and is part of the cache key, since
+    `location_tolerance` is in kilometers and is part of the cache key, since
     unlike the age filter it changes the SQL rather than being applied afterwards.
     """
-    cache_key = (col_id, spatial_tolerance)
+    cache_key = (col_id, location_tolerance)
     unit_index = column_unit_index.get()
     if cache_key in unit_index:
         return unit_index[cache_key]
@@ -305,7 +305,7 @@ def get_column_units(
 
     params = dict(
         col_id=col_id,
-        spatial_tolerance=spatial_tolerance,
+        location_tolerance=location_tolerance,
         use_concepts=MatchType.Concepts in types,
         use_synonyms=MatchType.Synonyms in types,
         use_adjacent_cols=MatchType.AdjacentCols in types,
@@ -378,7 +378,7 @@ def get_all_matched_units(
     t_age: float | None = None,
     b_age: float | None = None,
     age_tolerance: float = 0.0,
-    spatial_tolerance: float = DEFAULT_SPATIAL_TOLERANCE_KM,
+    location_tolerance: float = DEFAULT_LOCATION_TOLERANCE_KM,
 ) -> list[tuple]:
     """
     Return all units and stratigraphic names that match the given col_id.
@@ -386,14 +386,14 @@ def get_all_matched_units(
 
     `age_tolerance` widens the [t_age, b_age] window by that many millions of
     years on both ends, so a unit falling just short of overlapping it is still
-    returned. Each row is stamped with a `temporal_basis` recording which case it
+    returned. Each row is stamped with a `age_basis` recording which case it
     is.
 
-    `spatial_tolerance` is in kilometres and bounds how far an adjacent column may
+    `location_tolerance` is in kilometres and bounds how far an adjacent column may
     be from the one containing the query location.
     """
     units = get_column_units(
-        conn, col_id, types=types, spatial_tolerance=spatial_tolerance
+        conn, col_id, types=types, location_tolerance=location_tolerance
     )
     if b_age is not None:
         units = units.loc[units.t_age <= b_age + age_tolerance]
@@ -405,9 +405,9 @@ def get_all_matched_units(
 
     # A unit overlapping the unwidened window is a 'containing interval' match; one
     # that only fits once the tolerance is applied is an 'adjacent interval' match,
-    # mirroring how spatial_basis distinguishes containing from adjacent columns.
+    # mirroring how location_basis distinguishes containing from adjacent columns.
     # With no age window at all, no temporal filtering happened, so there is nothing
-    # to report and temporal_basis is left null. Callers pass +/-inf rather than None
+    # to report and age_basis is left null. Callers pass +/-inf rather than None
     # for an unconstrained window, hence the isfinite checks.
     constrained = (b_age is not None and isfinite(b_age)) or (
         t_age is not None and isfinite(t_age)
@@ -418,11 +418,11 @@ def get_all_matched_units(
             strict &= units.t_age <= b_age
         if t_age is not None:
             strict &= units.b_age >= t_age
-        units["temporal_basis"] = strict.map(
+        units["age_basis"] = strict.map(
             {True: "containing interval", False: "adjacent interval"}
         )
     else:
-        units["temporal_basis"] = None
+        units["age_basis"] = None
 
     u1 = units[units.strat_name_clean.notnull()]
     matched_rows = []

--- a/py-modules/match-utils/macrostrat/match_utils/__init__.py
+++ b/py-modules/match-utils/macrostrat/match_utils/__init__.py
@@ -1,7 +1,7 @@
 from contextvars import ContextVar
 
 from geopandas import GeoDataFrame
-from pandas import isna, read_sql
+from pandas import Series, isna, read_sql
 from pydantic import BaseModel
 from sqlalchemy.sql import text
 
@@ -64,6 +64,13 @@ MATCH_STRAT_NAMES_INFO = {
                 "Must be greater than t_age.",
                 "t_age": "number, late/upper age constraint in millions of years (Ma). "
                 "Must be less than b_age.",
+                "age_tolerance": "number, allowable gap in millions of years between the query "
+                "age window and a unit's age range. Default 0 (strict overlap). A unit falling "
+                "short of overlapping the window by no more than this amount is still matched, "
+                "and reported with temporal_basis='adjacent interval'. Requires an age window "
+                "to widen: supply interval, or both bounds via b_age/b_interval and "
+                "t_age/t_interval, otherwise the request is rejected with a 422. Does not "
+                "affect priority.",
                 "identifier": "string or integer, optional identifier to tag a query (e.g. a "
                 "collection ID). Passed through to the response for correlation.",
                 "all": "boolean, if true return all matches ordered by priority. "
@@ -121,6 +128,11 @@ MATCH_STRAT_NAMES_INFO = {
                 "One of: exact | concept | rank-up | rank-down | synonym",
                 "spatial_basis": "string, spatial relationship of the match. "
                 "One of: containing column | adjacent column",
+                "temporal_basis": "string, temporal relationship of the match. "
+                "One of: containing interval | adjacent interval. 'containing interval' means "
+                "the unit's age range overlaps the query age window; 'adjacent interval' means "
+                "it did not overlap but fell within age_tolerance of it. Without age_tolerance "
+                "every match is 'containing interval'.",
                 "t_age": "number, continuous time age model estimated top age, in Ma",
                 "b_age": "number, continuous time age model estimated bottom age, in Ma",
                 "priority": "number, match priority assigned after applying the selected priority ordering scheme. "
@@ -333,16 +345,36 @@ def get_all_matched_units(
     n_results: int | None = None,
     t_age: float | None = None,
     b_age: float | None = None,
+    age_tolerance: float = 0.0,
 ) -> list[tuple]:
     """
     Return all units and stratigraphic names that match the given col_id.
     Returns list of (row, is_exact_name_match) tuples.
+
+    `age_tolerance` widens the [t_age, b_age] window by that many millions of
+    years on both ends, so a unit falling just short of overlapping it is still
+    returned. Each row is stamped with a `temporal_basis` recording which case it
+    is.
     """
     units = get_column_units(conn, col_id, types=types)
     if b_age is not None:
-        units = units.loc[units.t_age <= b_age]
+        units = units.loc[units.t_age <= b_age + age_tolerance]
     if t_age is not None:
-        units = units.loc[units.b_age >= t_age]
+        units = units.loc[units.b_age >= t_age - age_tolerance]
+
+    # Copy so the frame cached in `column_unit_index` is never mutated. A unit
+    # overlapping the unwidened window is a 'containing interval' match; one that
+    # only fits once the tolerance is applied is an 'adjacent interval' match,
+    # mirroring how spatial_basis distinguishes containing from adjacent columns.
+    units = units.copy()
+    strict = Series(True, index=units.index)
+    if b_age is not None:
+        strict &= units.t_age <= b_age
+    if t_age is not None:
+        strict &= units.b_age >= t_age
+    units["temporal_basis"] = strict.map(
+        {True: "containing interval", False: "adjacent interval"}
+    )
 
     u1 = units[units.strat_name_clean.notnull()]
     matched_rows = []

--- a/py-modules/match-utils/macrostrat/match_utils/__init__.py
+++ b/py-modules/match-utils/macrostrat/match_utils/__init__.py
@@ -1,4 +1,5 @@
 from contextvars import ContextVar
+from math import isfinite
 
 from geopandas import GeoDataFrame
 from pandas import Series, isna, read_sql
@@ -87,7 +88,10 @@ MATCH_STRAT_NAMES_INFO = {
                 "identifier": "string or integer, optional identifier to tag a query (e.g. a "
                 "collection ID). Passed through to the response for correlation.",
                 "all": "boolean, if true return all matches ordered by priority. "
-                "If false (default), return only the highest priority match (priority=0.0).",
+                "If false (default), return only the highest priority match (priority=0.0). "
+                "On GET this is a URL parameter. On POST it works either way: ?all= sets the "
+                "default for the whole batch, and any item can override it with its own 'all' "
+                "key ('all': 1 / 'all': 0 or true/false).",
                 "name_basis": "string, filter results to only those with this name_basis. "
                 "One of: exact | concept | rank-down | rank-up | synonym. "
                 "Applied as a final step after matching and prioritization. "
@@ -124,7 +128,10 @@ MATCH_STRAT_NAMES_INFO = {
             ],
             "response_fields": {
                 "results": "array, list of match result objects, one per query.",
-                "results[].unit_matches": "array, matched units ordered by ascending priority.",
+                "results[].unit_matches": "array, matched units ordered by ascending priority. "
+                "At most one entry per (unit_id, col_id): where several stratigraphic names "
+                "resolve to the same unit, only the best-priority match for that unit is "
+                "returned.",
                 "results[].messages": "array, any warnings or errors for this query.",
                 "name_bases": "set of strings, the name_basis values present across all results.",
                 "strat_name_id": "integer, Macrostrat stratigraphic name ID",
@@ -141,11 +148,13 @@ MATCH_STRAT_NAMES_INFO = {
                 "One of: exact | concept | rank-up | rank-down | synonym",
                 "spatial_basis": "string, spatial relationship of the match. "
                 "One of: containing column | adjacent column",
-                "temporal_basis": "string, temporal relationship of the match. "
+                "temporal_basis": "string or null, temporal relationship of the match. "
                 "One of: containing interval | adjacent interval. 'containing interval' means "
                 "the unit's age range overlaps the query age window; 'adjacent interval' means "
-                "it did not overlap but fell within age_tolerance of it. Without age_tolerance "
-                "every match is 'containing interval'.",
+                "it did not overlap but fell within age_tolerance of it. With an age window but "
+                "no age_tolerance every match is 'containing interval'. Null when the request "
+                "supplied no age constraint at all (no interval, b_interval/t_interval, or "
+                "b_age/t_age), signalling that matching applied no temporal filter.",
                 "t_age": "number, continuous time age model estimated top age, in Ma",
                 "b_age": "number, continuous time age model estimated bottom age, in Ma",
                 "priority": "number, match priority assigned after applying the selected priority ordering scheme. "
@@ -391,19 +400,29 @@ def get_all_matched_units(
     if t_age is not None:
         units = units.loc[units.b_age >= t_age - age_tolerance]
 
-    # Copy so the frame cached in `column_unit_index` is never mutated. A unit
-    # overlapping the unwidened window is a 'containing interval' match; one that
-    # only fits once the tolerance is applied is an 'adjacent interval' match,
-    # mirroring how spatial_basis distinguishes containing from adjacent columns.
+    # Copy so the frame cached in `column_unit_index` is never mutated.
     units = units.copy()
-    strict = Series(True, index=units.index)
-    if b_age is not None:
-        strict &= units.t_age <= b_age
-    if t_age is not None:
-        strict &= units.b_age >= t_age
-    units["temporal_basis"] = strict.map(
-        {True: "containing interval", False: "adjacent interval"}
+
+    # A unit overlapping the unwidened window is a 'containing interval' match; one
+    # that only fits once the tolerance is applied is an 'adjacent interval' match,
+    # mirroring how spatial_basis distinguishes containing from adjacent columns.
+    # With no age window at all, no temporal filtering happened, so there is nothing
+    # to report and temporal_basis is left null. Callers pass +/-inf rather than None
+    # for an unconstrained window, hence the isfinite checks.
+    constrained = (b_age is not None and isfinite(b_age)) or (
+        t_age is not None and isfinite(t_age)
     )
+    if constrained:
+        strict = Series(True, index=units.index)
+        if b_age is not None:
+            strict &= units.t_age <= b_age
+        if t_age is not None:
+            strict &= units.b_age >= t_age
+        units["temporal_basis"] = strict.map(
+            {True: "containing interval", False: "adjacent interval"}
+        )
+    else:
+        units["temporal_basis"] = None
 
     u1 = units[units.strat_name_clean.notnull()]
     matched_rows = []

--- a/py-modules/match-utils/macrostrat/match_utils/__init__.py
+++ b/py-modules/match-utils/macrostrat/match_utils/__init__.py
@@ -18,6 +18,12 @@ from .utils import stored_procedure
 
 _column_unit_index = {}
 
+# The adjacent-column search previously used a 0.01-degree buffer. That is 1.11 km
+# north-south at any latitude, but only 0.86 km east-west at 39 degrees and 0.29 km
+# at 75 degrees. 1.11 km preserves the north-south reach exactly and makes the
+# east-west reach match it instead of narrowing toward the poles.
+DEFAULT_SPATIAL_TOLERANCE_KM = 1.11
+
 MATCH_STRAT_NAMES_INFO = {
     "success": {
         "v": 2,
@@ -71,6 +77,13 @@ MATCH_STRAT_NAMES_INFO = {
                 "to widen: supply interval, or both bounds via b_age/b_interval and "
                 "t_age/t_interval, otherwise the request is rejected with a 422. Does not "
                 "affect priority.",
+                "spatial_tolerance": "number, how far in kilometres an adjacent column may be "
+                "from the column containing the query location and still contribute matches. "
+                "Default 1.11, which preserves the reach of the 0.01-degree buffer it replaced. "
+                "Matches from outside the containing column are reported with "
+                "spatial_basis='adjacent column'. Columns tessellate, so neighbours share "
+                "edges and lie at distance 0 — a tolerance of 0 still admits every "
+                "edge-sharing column, and only larger values reach columns that do not touch.",
                 "identifier": "string or integer, optional identifier to tag a query (e.g. a "
                 "collection ID). Passed through to the response for correlation.",
                 "all": "boolean, if true return all matches ordered by priority. "
@@ -262,18 +275,28 @@ def ensure_single(col_ids, entity="column"):
 column_unit_index = ContextVar("column_unit_index", default={})
 
 
-def get_column_units(conn, col_id, types: list[MatchType] = None):
+def get_column_units(
+    conn,
+    col_id,
+    types: list[MatchType] = None,
+    spatial_tolerance: float = DEFAULT_SPATIAL_TOLERANCE_KM,
+):
     """
     Get a unit that matches a given stratigraphic name
+
+    `spatial_tolerance` is in kilometers and is part of the cache key, since
+    unlike the age filter it changes the SQL rather than being applied afterwards.
     """
+    cache_key = (col_id, spatial_tolerance)
     unit_index = column_unit_index.get()
-    if col_id in unit_index:
-        return unit_index[col_id]
+    if cache_key in unit_index:
+        return unit_index[cache_key]
     # TODO need to update the match types model to exact, concept, rank-up, rank-down
     types = get_match_types(types)
 
     params = dict(
         col_id=col_id,
+        spatial_tolerance=spatial_tolerance,
         use_concepts=MatchType.Concepts in types,
         use_synonyms=MatchType.Synonyms in types,
         use_adjacent_cols=MatchType.AdjacentCols in types,
@@ -298,7 +321,7 @@ def get_column_units(conn, col_id, types: list[MatchType] = None):
 
     # Set the index to a shared cache
     unit_index = column_unit_index.get()
-    unit_index[col_id] = units_df
+    unit_index[cache_key] = units_df
     column_unit_index.set(unit_index)
     return units_df
 
@@ -346,6 +369,7 @@ def get_all_matched_units(
     t_age: float | None = None,
     b_age: float | None = None,
     age_tolerance: float = 0.0,
+    spatial_tolerance: float = DEFAULT_SPATIAL_TOLERANCE_KM,
 ) -> list[tuple]:
     """
     Return all units and stratigraphic names that match the given col_id.
@@ -355,8 +379,13 @@ def get_all_matched_units(
     years on both ends, so a unit falling just short of overlapping it is still
     returned. Each row is stamped with a `temporal_basis` recording which case it
     is.
+
+    `spatial_tolerance` is in kilometres and bounds how far an adjacent column may
+    be from the one containing the query location.
     """
-    units = get_column_units(conn, col_id, types=types)
+    units = get_column_units(
+        conn, col_id, types=types, spatial_tolerance=spatial_tolerance
+    )
     if b_age is not None:
         units = units.loc[units.t_age <= b_age + age_tolerance]
     if t_age is not None:

--- a/py-modules/match-utils/macrostrat/match_utils/models.py
+++ b/py-modules/match-utils/macrostrat/match_utils/models.py
@@ -18,7 +18,9 @@ class MatchResult(BaseModel):
     depth: Optional[int]
     name_basis: str
     spatial_basis: str
-    temporal_basis: str
+    # Null when the request applied no age constraint at all, to distinguish
+    # "not filtered on time" from "filtered and it overlapped".
+    temporal_basis: Optional[str]
     t_age: float
     b_age: float
     priority: float

--- a/py-modules/match-utils/macrostrat/match_utils/models.py
+++ b/py-modules/match-utils/macrostrat/match_utils/models.py
@@ -17,10 +17,10 @@ class MatchResult(BaseModel):
     project_id: Optional[int]
     depth: Optional[int]
     name_basis: str
-    spatial_basis: str
+    location_basis: str
     # Null when the request applied no age constraint at all, to distinguish
     # "not filtered on time" from "filtered and it overlapped".
-    temporal_basis: Optional[str]
+    age_basis: Optional[str]
     t_age: float
     b_age: float
     priority: float

--- a/py-modules/match-utils/macrostrat/match_utils/models.py
+++ b/py-modules/match-utils/macrostrat/match_utils/models.py
@@ -18,6 +18,7 @@ class MatchResult(BaseModel):
     depth: Optional[int]
     name_basis: str
     spatial_basis: str
+    temporal_basis: str
     t_age: float
     b_age: float
     priority: float

--- a/py-modules/match-utils/macrostrat/match_utils/sql/column-strat-names.sql
+++ b/py-modules/match-utils/macrostrat/match_utils/sql/column-strat-names.sql
@@ -4,6 +4,11 @@
 
   Parameters:
   - col_id: The identity of a column
+  - spatial_tolerance: How far, in kilometres, an adjacent column may be from the
+      selected one — exactly the value the caller supplied, converted to metres
+      here. ST_DWithin on geography is the same predicate as
+      ST_Intersects(col_area, ST_Buffer(selected, d)) but measures true distance,
+      so the reach no longer narrows east-west as latitude increases.
   - use_adjacent_cols: Allow units from adjacent columns
   - use_concepts: Allow concepts
   - use_column_units: Allow units directly linked to colums
@@ -27,7 +32,7 @@ WITH RECURSIVE cols AS (
            cols.col_id = sel.col_id selected
     FROM cols
     JOIN selected_col sel
-      ON ST_Intersects(cols.col_area, ST_Buffer(sel.col_area, 0.01))
+      ON ST_DWithin(cols.col_area::geography, sel.col_area::geography, :spatial_tolerance * 1000)
     WHERE :use_adjacent_cols
        OR cols.col_id = sel.col_id
 ), strat_units AS (
@@ -184,7 +189,11 @@ with_footprints_index AS (
     AND :use_footprint_index
   ORDER BY sort_order, is_selected_column DESC NULLS LAST
 ), res AS (
-  SELECT DISTINCT ON (sort_order, is_selected_column, strat_name_id)
+  /** col_id and unit_id are part of the key so that every distinct unit a name
+    resolves to is returned. Keying on strat_name_id alone let one arbitrary column
+    win per name, so widening spatial_tolerance could replace a near match with a
+    distant one, and a rank-up match could hide the direct match in its column. */
+  SELECT DISTINCT ON (sort_order, is_selected_column, strat_name_id, col_id, unit_id)
     sort_order priority,
     strat_name_id,
     strat_name,
@@ -204,7 +213,7 @@ with_footprints_index AS (
     t_age,
     b_age
   FROM with_footprints_index
-  ORDER BY sort_order, is_selected_column DESC, strat_name_id
+  ORDER BY sort_order, is_selected_column DESC, strat_name_id, col_id, unit_id
 )
 -- Start adding metadata to matches
 SELECT

--- a/py-modules/match-utils/macrostrat/match_utils/sql/column-strat-names.sql
+++ b/py-modules/match-utils/macrostrat/match_utils/sql/column-strat-names.sql
@@ -4,7 +4,7 @@
 
   Parameters:
   - col_id: The identity of a column
-  - spatial_tolerance: How far, in kilometres, an adjacent column may be from the
+  - location_tolerance: How far, in kilometres, an adjacent column may be from the
       selected one — exactly the value the caller supplied, converted to metres
       here. ST_DWithin on geography is the same predicate as
       ST_Intersects(col_area, ST_Buffer(selected, d)) but measures true distance,
@@ -32,7 +32,7 @@ WITH RECURSIVE cols AS (
            cols.col_id = sel.col_id selected
     FROM cols
     JOIN selected_col sel
-      ON ST_DWithin(cols.col_area::geography, sel.col_area::geography, :spatial_tolerance * 1000)
+      ON ST_DWithin(cols.col_area::geography, sel.col_area::geography, :location_tolerance * 1000)
     WHERE :use_adjacent_cols
        OR cols.col_id = sel.col_id
 ), strat_units AS (
@@ -191,7 +191,7 @@ with_footprints_index AS (
 ), res AS (
   /** col_id and unit_id are part of the key so that every distinct unit a name
     resolves to is returned. Keying on strat_name_id alone let one arbitrary column
-    win per name, so widening spatial_tolerance could replace a near match with a
+    win per name, so widening location_tolerance could replace a near match with a
     distant one, and a rank-up match could hide the direct match in its column. */
   SELECT DISTINCT ON (sort_order, is_selected_column, strat_name_id, col_id, unit_id)
     sort_order priority,
@@ -209,7 +209,7 @@ with_footprints_index AS (
       WHEN is_selected_column != 0
         THEN 'containing column'
       ELSE 'adjacent column'
-      END AS   spatial_basis,
+      END AS   location_basis,
     t_age,
     b_age
   FROM with_footprints_index

--- a/py-modules/match-utils/macrostrat/match_utils/test_match_strat_names.py
+++ b/py-modules/match-utils/macrostrat/match_utils/test_match_strat_names.py
@@ -75,12 +75,12 @@ def test_get_column_units(db):
     assert len(project_ids) == 1
 
 
-def test_column_units_have_spatial_basis(db):
-    """All rows should have a spatial_basis of containing or adjacent column."""
+def test_column_units_have_location_basis(db):
+    """All rows should have a location_basis of containing or adjacent column."""
     with db.engine.connect() as conn:
         units = get_column_units(conn, col_id=490)
-    assert "spatial_basis" in units.columns
-    assert set(units["spatial_basis"].dropna().unique()).issubset(
+    assert "location_basis" in units.columns
+    assert set(units["location_basis"].dropna().unique()).issubset(
         {"containing column", "adjacent column"}
     )
 
@@ -210,12 +210,12 @@ def test_match_count(db):
     assert unit_ids == {1852}
 
 
-def test_spatial_basis_containing_column(db):
-    """Direct column match should have spatial_basis='containing column'."""
+def test_location_basis_containing_column(db):
+    """Direct column match should have location_basis='containing column'."""
     names = standardize_names("Navajo Sandstone")
     with db.engine.connect() as conn:
         rows = get_all_matched_units(conn, 490, names)
-    containing = [row for row in rows if row["spatial_basis"] == "containing column"]
+    containing = [row for row in rows if row["location_basis"] == "containing column"]
     assert len(containing) > 0
 
 

--- a/py-modules/match-utils/macrostrat/match_utils/test_match_utils_v2.py
+++ b/py-modules/match-utils/macrostrat/match_utils/test_match_utils_v2.py
@@ -80,13 +80,13 @@ expected_match_keys = {
     "project_id",
     "depth",
     "name_basis",
-    "spatial_basis",
+    "location_basis",
     "t_age",
     "b_age",
     "priority",
 }
 valid_name_bases = {"exact", "concept", "rank-up", "rank-down", "synonym"}
-valid_spatial_bases = {"containing column", "adjacent column"}
+valid_location_bases = {"containing column", "adjacent column"}
 
 
 # -- Unit tests for response structure -------------------------------------
@@ -113,14 +113,14 @@ def test_match_result_name_basis_values():
         project_id=1,
         depth=0,
         name_basis="exact",
-        spatial_basis="containing column",
-        temporal_basis="containing interval",
+        location_basis="containing column",
+        age_basis="containing interval",
         t_age=100.0,
         b_age=200.0,
         priority=0.0,
     )
     assert result.name_basis in valid_name_bases
-    assert result.spatial_basis in valid_spatial_bases
+    assert result.location_basis in valid_location_bases
 
 
 def test_priority_ascending_order(db):

--- a/py-modules/match-utils/macrostrat/match_utils/test_match_utils_v2.py
+++ b/py-modules/match-utils/macrostrat/match_utils/test_match_utils_v2.py
@@ -114,6 +114,7 @@ def test_match_result_name_basis_values():
         depth=0,
         name_basis="exact",
         spatial_basis="containing column",
+        temporal_basis="containing interval",
         t_age=100.0,
         b_age=200.0,
         priority=0.0,

--- a/services/api-v3/api/match/__init__.py
+++ b/services/api-v3/api/match/__init__.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field, ValidationError, model_validator
 
 from macrostrat.match_utils import (
+    DEFAULT_SPATIAL_TOLERANCE_KM,
     MATCH_STRAT_NAMES_INFO,
     MatchResult,
     create_ignore_list,
@@ -138,6 +139,18 @@ class MatchQueryFields(BaseModel):
             "temporal_basis='adjacent interval'. Requires an age window to widen: "
             "supply `interval`, or both bounds via b_age/b_interval and t_age/t_interval. "
             "Does not affect `priority`."
+        ),
+    )
+    spatial_tolerance: float = Field(
+        DEFAULT_SPATIAL_TOLERANCE_KM,
+        ge=0,
+        description=(
+            "How far, in kilometers, an adjacent column may be from the column "
+            "containing the query location and still contribute matches. Matches from "
+            "outside that column are reported with spatial_basis='adjacent column', "
+            "as before. Note that columns tessellate, so neighbours share edges and "
+            "lie at distance 0: a tolerance of 0 still admits every edge-sharing "
+            "column. Only a larger value reaches columns that do not touch."
         ),
     )
     priority: Literal["strat_name", "location"] = Field(
@@ -678,6 +691,7 @@ def build_match_data(db, params):
                 t_age=age_constraint.t_age,
                 b_age=age_constraint.b_age,
                 age_tolerance=params.age_tolerance,
+                spatial_tolerance=params.spatial_tolerance,
             )
         raw_name = (params.strat_name or params.concept_name or "").strip().lower()
         for row in rows:

--- a/services/api-v3/api/match/__init__.py
+++ b/services/api-v3/api/match/__init__.py
@@ -4,13 +4,7 @@ from datetime import datetime
 from typing import Annotated, Literal, Optional
 
 from fastapi import APIRouter, HTTPException, Query
-from pydantic import (
-    BaseModel,
-    BeforeValidator,
-    Field,
-    ValidationError,
-    model_validator,
-)
+from pydantic import BaseModel, BeforeValidator, Field, ValidationError, model_validator
 
 from macrostrat.match_utils import (
     DEFAULT_LOCATION_TOLERANCE_KM,

--- a/services/api-v3/api/match/__init__.py
+++ b/services/api-v3/api/match/__init__.py
@@ -4,7 +4,13 @@ from datetime import datetime
 from typing import Annotated, Literal, Optional
 
 from fastapi import APIRouter, HTTPException, Query
-from pydantic import BaseModel, Field, ValidationError, model_validator
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    Field,
+    ValidationError,
+    model_validator,
+)
 
 from macrostrat.match_utils import (
     DEFAULT_SPATIAL_TOLERANCE_KM,
@@ -61,6 +67,19 @@ def setup_matcher(db):
 
 
 router = APIRouter(tags=["match"])
+
+
+def _fold_case(value):
+    """Lower-case incoming strings so enumerated parameters accept any casing."""
+    return value.casefold() if isinstance(value, str) else value
+
+
+class UnknownIntervalError(ValueError):
+    """Raised when an interval name or ID is not present in macrostrat.intervals.
+
+    Surfaced as a 422 rather than the 500 that resolving None used to produce, so a
+    typo in a bulk request reports the bad name instead of crashing.
+    """
 
 
 class AbsoluteAgeConstraint(BaseModel):
@@ -153,7 +172,9 @@ class MatchQueryFields(BaseModel):
             "column. Only a larger value reaches columns that do not touch."
         ),
     )
-    priority: Literal["strat_name", "location"] = Field(
+    priority: Annotated[
+        Literal["strat_name", "location"], BeforeValidator(_fold_case)
+    ] = Field(
         "location",
         description=(
             "Controls how match results are prioritized when multiple possible matches are found. "
@@ -173,17 +194,27 @@ class MatchQueryFields(BaseModel):
         b_age = float("inf")
         t_age = -float("inf")
 
+        def resolve(value, field):
+            """Look up an interval, failing loudly if Macrostrat has no such name."""
+            intv = get_interval(value)
+            if intv is None:
+                raise UnknownIntervalError(
+                    f"{field}='{value}' does not exist in Macrostrat. See "
+                    "/api/v2/defs/intervals for the list of valid interval names and IDs."
+                )
+            return intv
+
         # Apply interval-based age constraints in order of specificity, complaining if conflicting
         if self.interval is not None:
-            intv = get_interval(self.interval)
+            intv = resolve(self.interval, "interval")
             b_age = intv.age_bottom
             t_age = intv.age_top
 
         if self.b_interval is not None:
-            intv = get_interval(self.b_interval)
+            intv = resolve(self.b_interval, "b_interval")
             b_age = min(b_age, intv.age_bottom)
         if self.t_interval is not None:
-            intv = get_interval(self.t_interval)
+            intv = resolve(self.t_interval, "t_interval")
             t_age = max(t_age, intv.age_top)
         if self.b_age is not None:
             b_age = min(b_age, self.b_age)
@@ -288,7 +319,12 @@ class MatchAPIResponse(BaseModel):
     messages: set[MatchMessage] | None = None
 
 
-NameBasis = Literal["exact", "concept", "rank-down", "rank-up", "synonym"]
+# Enumerated string parameters are matched case-insensitively: pydantic compares
+# Literal members exactly, so the value is folded before validation.
+NameBasis = Annotated[
+    Literal["exact", "concept", "rank-down", "rank-up", "synonym"],
+    BeforeValidator(_fold_case),
+]
 SpatialBasis = Literal["containing column", "adjacent column"]
 
 
@@ -315,8 +351,26 @@ class MatchDefaults(MatchQueryFields, MatchOptions):
     Any field omitted from a body item inherits the value provided here, and a
     field set on a body item overrides it. This keeps a single request shape (a
     list of MatchQuery objects) while letting callers factor out whatever is
-    common — a location, a strat_name, an age range — into the query string.
+    common — a location, a strat_name, an age range, a result depth — into the
+    query string.
     """
+
+
+class MatchBatchItem(MatchQueryFields):
+    """One item of a batch POST body.
+
+    Carries its own optional `all`, which follows the same inheritance rule as
+    every other field: omitted, it falls back to the `?all=` query parameter; set,
+    it overrides that for this item alone. Without this field a body-level
+    "all": 1 was silently dropped.
+    """
+
+    all: bool = Field(
+        False,
+        description="Return all matches for this item, ordered by priority. "
+        "Overrides the `?all=` query parameter for this item. If neither is set, "
+        "only the highest-priority match is returned. Accepts true/false or 1/0.",
+    )
 
 
 class MatchPriorityOrder(BaseModel):
@@ -409,15 +463,31 @@ def assign_priorities(
 
 
 def get_interval(interval: int | str) -> Optional[Interval]:
-    """Retrieve interval information by ID or name."""
+    """Retrieve interval information by ID or name.
+
+    Name matching is case-insensitive, but an exact match always wins. A few
+    interval names differ only by case — 'M10n' and 'M10N' are distinct
+    magnetochrons — so folding case unconditionally would make those ambiguous.
+    Trying the exact spelling first keeps them addressable while still accepting
+    'kasimovian' for 'Kasimovian'.
+    """
     interval_list = _intervals.get()
     if interval_list is None:
         raise ValueError("Interval list not initialized.")
 
+    if isinstance(interval, int):
+        for intv in interval_list:
+            if intv.id == interval:
+                return intv
+        return None
+
     for intv in interval_list:
-        if isinstance(interval, int) and intv.id == interval:
+        if intv.interval_name == interval:
             return intv
-        elif isinstance(interval, str) and intv.interval_name == interval:
+
+    lowered = interval.casefold()
+    for intv in interval_list:
+        if intv.interval_name.casefold() == lowered:
             return intv
     return None
 
@@ -461,7 +531,7 @@ def match_units(
 
 @router.post("/strat-names")
 def match_units_multi(
-    body: list[MatchQueryFields],
+    body: list[MatchBatchItem],
     defaults: Annotated[MatchDefaults, Query()],
     database: DatabaseDep,
 ) -> MatchAPIResponse:
@@ -477,8 +547,8 @@ def match_units_multi(
 
     :return: MatchAPIResponse
     """
-    # Response-shaping options are request-wide (query string only).
-    opts = MatchOptions(all=defaults.all, name_basis=defaults.name_basis)
+    # name_basis filters the whole response; `all` is per-item, defaulting to ?all=.
+    opts = MatchOptions(name_basis=defaults.name_basis)
     # Per-item defaults: only the query params the caller actually set.
     default_fields = defaults.model_dump(
         exclude_unset=True, exclude={"all", "name_basis"}
@@ -490,15 +560,24 @@ def match_units_multi(
         )
 
     # Merge defaults under each item (item wins) and validate the result.
-    queries: list[MatchQuery] = []
+    queries: list[tuple[MatchQuery, bool]] = []
     for index, item in enumerate(body):
-        merged = {**default_fields, **item.model_dump(exclude_unset=True)}
+        item_fields = item.model_dump(exclude_unset=True)
+        # `all` shapes the response rather than the query, so it travels alongside
+        # the MatchQuery. Unset on the item means inherit the query-string value.
+        return_all = bool(item_fields.pop("all", defaults.all))
+        merged = {**default_fields, **item_fields}
         try:
-            queries.append(MatchQuery(**merged))
+            queries.append((MatchQuery(**merged), return_all))
         except ValidationError as err:
+            # include_context=False drops pydantic's `ctx`, which holds the raw
+            # exception object. Without this the detail is not JSON serializable and
+            # FastAPI turns the 422 into a 500 while encoding the response.
             raise HTTPException(
                 status_code=422,
-                detail=[{**e, "index": index} for e in err.errors()],
+                detail=[
+                    {**e, "index": index} for e in err.errors(include_context=False)
+                ],
             )
 
     db = database.sync
@@ -506,19 +585,32 @@ def match_units_multi(
         setup_matcher(db)
 
         all_results: list[MatchData] = []
-        for params in queries:
+        # Built in lockstep with all_results so the two stay index-aligned.
+        all_flags: list[bool] = []
+        for params, return_all in queries:
             match_data = build_match_data(db, params)
-            if match_data is not None:
-                all_results.append(match_data)
+            if match_data is None:
+                continue
+            all_results.append(match_data)
+            all_flags.append(return_all)
 
-        return generate_response(all_results, opts)
+        return generate_response(all_results, opts, all_flags=all_flags)
     finally:
         db.session.remove()
 
 
 def generate_response(
-    results: list[MatchData], opts: MatchOptions, messages: list[MatchMessage] = None
+    results: list[MatchData],
+    opts: MatchOptions,
+    messages: list[MatchMessage] = None,
+    all_flags: list[bool] | None = None,
 ) -> MatchAPIResponse:
+    """Apply response-shaping options and wrap results in a MatchAPIResponse.
+
+    `opts.all` applies request-wide, which is what the GET endpoint wants. The batch
+    endpoint passes `all_flags` instead — one flag per result, same order — because
+    there `all` is set per body item.
+    """
     # Filter by name_basis after matching/prioritization, keeping only matches
     # whose name_basis equals the requested value.
     if opts.name_basis is not None:
@@ -533,20 +625,46 @@ def generate_response(
             for result in results
         ]
 
-    # When all=False, keep only the best (lowest-priority) match that remain.
+    # Unless all matches were asked for, keep only the best (lowest-priority) ones.
     # With no name_basis filter the best priority is 0.0, preserving prior behavior.
-    if not opts.all:
-        reduced: list[MatchData] = []
-        for result in results:
-            if result.unit_matches:
-                best = min(m.priority for m in result.unit_matches)
-                kept = [m for m in result.unit_matches if m.priority == best]
-            else:
-                kept = []
-            reduced.append(
-                MatchData(id=result.id, unit_matches=kept, messages=result.messages)
+    reduced: list[MatchData] = []
+    for index, result in enumerate(results):
+        return_all = all_flags[index] if all_flags is not None else opts.all
+        if return_all or not result.unit_matches:
+            reduced.append(result)
+            continue
+        best = min(m.priority for m in result.unit_matches)
+        reduced.append(
+            MatchData(
+                id=result.id,
+                unit_matches=[m for m in result.unit_matches if m.priority == best],
+                messages=result.messages,
             )
-        results = reduced
+        )
+    results = reduced
+
+    # Finally, collapse repeats of the same matched unit. A unit can be reached by
+    # several stratigraphic names (e.g. both 'Lawrence' and 'Lawrence Shale' resolve
+    # to unit 3891), which produced rows differing only in strat_name_id. Matches
+    # arrive sorted by ascending priority, so the first appearance of a
+    # (unit_id, col_id) pair is its best one and later repeats add nothing.
+    # Footprint-index matches carry no unit_id and are always kept.
+    deduped: list[MatchData] = []
+    for result in results:
+        seen: set[tuple[int, int]] = set()
+        kept: list[MatchResult] = []
+        for match in result.unit_matches:
+            if match.unit_id is not None:
+                key = (match.unit_id, match.col_id)
+                if key in seen:
+                    continue
+                seen.add(key)
+            kept.append(match)
+        deduped.append(
+            MatchData(id=result.id, unit_matches=kept, messages=result.messages)
+        )
+    results = deduped
+
     _messages: set[MatchMessage] = set()
 
     for result in results:
@@ -620,7 +738,10 @@ def compute_name_basis(
 def build_match_data(db, params):
     """Build MatchData for a single MatchQuery."""
 
-    age_constraint = params.get_age_range()
+    try:
+        age_constraint = params.get_age_range()
+    except UnknownIntervalError as err:
+        raise HTTPException(status_code=422, detail=str(err))
     print("age_constraint", age_constraint)
     res = params.model_dump()
     # Add resolved numeric age constraints to context if provided

--- a/services/api-v3/api/match/__init__.py
+++ b/services/api-v3/api/match/__init__.py
@@ -128,6 +128,18 @@ class MatchQueryFields(BaseModel):
     )
     b_age: float | None = Field(None, description="Early/lower age constraint in Ma")
     t_age: float | None = Field(None, description="Late/upper age constraint in Ma")
+    age_tolerance: float = Field(
+        0.0,
+        ge=0,
+        description=(
+            "Allowable gap, in millions of years, between the query age window and a "
+            "unit's age range. A unit falling short of overlapping the window by no "
+            "more than this amount is still matched, and reported with "
+            "temporal_basis='adjacent interval'. Requires an age window to widen: "
+            "supply `interval`, or both bounds via b_age/b_interval and t_age/t_interval. "
+            "Does not affect `priority`."
+        ),
+    )
     priority: Literal["strat_name", "location"] = Field(
         "location",
         description=(
@@ -197,6 +209,20 @@ class MatchQuery(MatchQueryFields):
         if self.strat_name is not None and self.strat_name_id is not None:
             raise ValueError(
                 "Only one of strat_name or strat_name_id can be provided, not both."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_age_tolerance(self):
+        """A tolerance needs an age window to widen, or it silently does nothing."""
+        has_window = self.interval is not None or (
+            (self.b_age is not None or self.b_interval is not None)
+            and (self.t_age is not None or self.t_interval is not None)
+        )
+        if self.age_tolerance > 0 and not has_window:
+            raise ValueError(
+                "age_tolerance requires an age window to widen: provide `interval`, "
+                "or both `b_age`/`b_interval` and `t_age`/`t_interval`."
             )
         return self
 
@@ -651,6 +677,7 @@ def build_match_data(db, params):
                 names,
                 t_age=age_constraint.t_age,
                 b_age=age_constraint.b_age,
+                age_tolerance=params.age_tolerance,
             )
         raw_name = (params.strat_name or params.concept_name or "").strip().lower()
         for row in rows:

--- a/services/api-v3/api/match/__init__.py
+++ b/services/api-v3/api/match/__init__.py
@@ -13,7 +13,7 @@ from pydantic import (
 )
 
 from macrostrat.match_utils import (
-    DEFAULT_SPATIAL_TOLERANCE_KM,
+    DEFAULT_LOCATION_TOLERANCE_KM,
     MATCH_STRAT_NAMES_INFO,
     MatchResult,
     create_ignore_list,
@@ -155,18 +155,18 @@ class MatchQueryFields(BaseModel):
             "Allowable gap, in millions of years, between the query age window and a "
             "unit's age range. A unit falling short of overlapping the window by no "
             "more than this amount is still matched, and reported with "
-            "temporal_basis='adjacent interval'. Requires an age window to widen: "
+            "age_basis='adjacent interval'. Requires an age window to widen: "
             "supply `interval`, or both bounds via b_age/b_interval and t_age/t_interval. "
             "Does not affect `priority`."
         ),
     )
-    spatial_tolerance: float = Field(
-        DEFAULT_SPATIAL_TOLERANCE_KM,
+    location_tolerance: float = Field(
+        DEFAULT_LOCATION_TOLERANCE_KM,
         ge=0,
         description=(
             "How far, in kilometers, an adjacent column may be from the column "
             "containing the query location and still contribute matches. Matches from "
-            "outside that column are reported with spatial_basis='adjacent column', "
+            "outside that column are reported with location_basis='adjacent column', "
             "as before. Note that columns tessellate, so neighbours share edges and "
             "lie at distance 0: a tolerance of 0 still admits every edge-sharing "
             "column. Only a larger value reaches columns that do not touch."
@@ -325,7 +325,7 @@ NameBasis = Annotated[
     Literal["exact", "concept", "rank-down", "rank-up", "synonym"],
     BeforeValidator(_fold_case),
 ]
-SpatialBasis = Literal["containing column", "adjacent column"]
+LocationBasis = Literal["containing column", "adjacent column"]
 
 
 class MatchOptions(BaseModel):
@@ -379,7 +379,7 @@ class MatchPriorityOrder(BaseModel):
     Each rule combines two pieces of information:
     - name_basis: how the user's input stratigraphic name matched the database record
       such as exact, concept, rank-down, rank-up, or synonym.
-    - spatial_basis: how the matched unit relates to the input location or column,
+    - location_basis: how the matched unit relates to the input location or column,
       such as containing column or adjacent column.
     The API supports different priority schemes. With priority='location', spatial
     relationship is favored first, so containing-column matches are ranked before
@@ -394,7 +394,7 @@ class MatchPriorityOrder(BaseModel):
             "For example, 'exact' means the input name directly matched the database "
         ),
     )
-    spatial_basis: SpatialBasis = Field(
+    location_basis: LocationBasis = Field(
         ...,
         description=(
             "Spatial relationship between the matched unit and the column location. "
@@ -406,41 +406,41 @@ class MatchPriorityOrder(BaseModel):
     def priority_matches(self, result: MatchResult) -> bool:
         return (
             result.name_basis == self.name_basis
-            and result.spatial_basis == self.spatial_basis
+            and result.location_basis == self.location_basis
         )
 
 
 PRIORITY_ORDER = [
-    MatchPriorityOrder(name_basis="exact", spatial_basis="containing column"),
-    MatchPriorityOrder(name_basis="exact", spatial_basis="adjacent column"),
-    MatchPriorityOrder(name_basis="concept", spatial_basis="containing column"),
-    MatchPriorityOrder(name_basis="rank-down", spatial_basis="containing column"),
-    MatchPriorityOrder(name_basis="concept", spatial_basis="adjacent column"),
-    MatchPriorityOrder(name_basis="rank-down", spatial_basis="adjacent column"),
-    MatchPriorityOrder(name_basis="rank-up", spatial_basis="containing column"),
-    MatchPriorityOrder(name_basis="rank-up", spatial_basis="adjacent column"),
-    MatchPriorityOrder(name_basis="synonym", spatial_basis="containing column"),
-    MatchPriorityOrder(name_basis="synonym", spatial_basis="adjacent column"),
+    MatchPriorityOrder(name_basis="exact", location_basis="containing column"),
+    MatchPriorityOrder(name_basis="exact", location_basis="adjacent column"),
+    MatchPriorityOrder(name_basis="concept", location_basis="containing column"),
+    MatchPriorityOrder(name_basis="rank-down", location_basis="containing column"),
+    MatchPriorityOrder(name_basis="concept", location_basis="adjacent column"),
+    MatchPriorityOrder(name_basis="rank-down", location_basis="adjacent column"),
+    MatchPriorityOrder(name_basis="rank-up", location_basis="containing column"),
+    MatchPriorityOrder(name_basis="rank-up", location_basis="adjacent column"),
+    MatchPriorityOrder(name_basis="synonym", location_basis="containing column"),
+    MatchPriorityOrder(name_basis="synonym", location_basis="adjacent column"),
 ]
 
 PRIORITY_ORDER_LOCATION = [
-    MatchPriorityOrder(name_basis="exact", spatial_basis="containing column"),
-    MatchPriorityOrder(name_basis="concept", spatial_basis="containing column"),
-    MatchPriorityOrder(name_basis="rank-down", spatial_basis="containing column"),
-    MatchPriorityOrder(name_basis="rank-up", spatial_basis="containing column"),
-    MatchPriorityOrder(name_basis="synonym", spatial_basis="containing column"),
-    MatchPriorityOrder(name_basis="exact", spatial_basis="adjacent column"),
-    MatchPriorityOrder(name_basis="concept", spatial_basis="adjacent column"),
-    MatchPriorityOrder(name_basis="rank-down", spatial_basis="adjacent column"),
-    MatchPriorityOrder(name_basis="rank-up", spatial_basis="adjacent column"),
-    MatchPriorityOrder(name_basis="synonym", spatial_basis="adjacent column"),
+    MatchPriorityOrder(name_basis="exact", location_basis="containing column"),
+    MatchPriorityOrder(name_basis="concept", location_basis="containing column"),
+    MatchPriorityOrder(name_basis="rank-down", location_basis="containing column"),
+    MatchPriorityOrder(name_basis="rank-up", location_basis="containing column"),
+    MatchPriorityOrder(name_basis="synonym", location_basis="containing column"),
+    MatchPriorityOrder(name_basis="exact", location_basis="adjacent column"),
+    MatchPriorityOrder(name_basis="concept", location_basis="adjacent column"),
+    MatchPriorityOrder(name_basis="rank-down", location_basis="adjacent column"),
+    MatchPriorityOrder(name_basis="rank-up", location_basis="adjacent column"),
+    MatchPriorityOrder(name_basis="synonym", location_basis="adjacent column"),
 ]
 
 
 def assign_priorities(
     results: list[MatchResult], priority: str = "location"
 ) -> list[MatchResult]:
-    """Assign consecutive priorities based on name_basis/spatial_basis combinations present."""
+    """Assign consecutive priorities based on name_basis/location_basis combinations present."""
 
     order = PRIORITY_ORDER_LOCATION if priority == "location" else PRIORITY_ORDER
     present: list[MatchPriorityOrder] = []
@@ -812,7 +812,7 @@ def build_match_data(db, params):
                 t_age=age_constraint.t_age,
                 b_age=age_constraint.b_age,
                 age_tolerance=params.age_tolerance,
-                spatial_tolerance=params.spatial_tolerance,
+                location_tolerance=params.location_tolerance,
             )
         raw_name = (params.strat_name or params.concept_name or "").strip().lower()
         for row in rows:

--- a/services/api-v3/api/match/test_match_route.py
+++ b/services/api-v3/api/match/test_match_route.py
@@ -16,7 +16,8 @@ from . import MatchQuery, router, setup_intervals
 # TODO: just import the enums from the parent module
 valid_name_bases = {"exact", "concept", "rank-up", "rank-down", "synonym"}
 valid_spatial_bases = {"containing column", "adjacent column"}
-valid_temporal_bases = {"containing interval", "adjacent interval"}
+# None is valid: an unconstrained query applies no temporal filter at all.
+valid_temporal_bases = {"containing interval", "adjacent interval", None}
 
 
 def assert_valid_unit_matches(matches):
@@ -476,6 +477,7 @@ LAWRENCE = {
     "interval": "Kasimovian",
 }
 LAWRENCE_NO_INTERVAL = {k: v for k, v in LAWRENCE.items() if k != "interval"}
+LAWRENCE_POSITION = {"lat": LAWRENCE["lat"], "lng": LAWRENCE["lng"]}
 
 
 def test_strict_age_bounds_miss_the_containing_column(client):
@@ -536,13 +538,52 @@ def test_age_tolerance_smaller_than_the_gap_changes_nothing(client):
 
 @mark.parametrize(
     "age_params",
-    [{}, {"interval": "Kasimovian"}, {"b_age": 307.0, "t_age": 303.7}],
-    ids=["unconstrained", "interval", "absolute-ages"],
+    [
+        {"interval": "Kasimovian"},
+        {"b_age": 307.0, "t_age": 303.7},
+        {"b_interval": "Kasimovian", "t_interval": "Kasimovian"},
+    ],
+    ids=["interval", "absolute-ages", "b/t-intervals"],
 )
 def test_temporal_basis_is_containing_without_tolerance(client, age_params):
-    """With no age_tolerance every match overlapped the window outright."""
+    """Given an age window but no tolerance, every match overlapped it outright."""
     response = client.get(
         "/strat-names", params={**LAWRENCE_NO_INTERVAL, **age_params, "all": True}
+    )
+    assert response.status_code == 200
+    matches = response.json()["results"][0]["unit_matches"]
+    assert len(matches) >= 1
+    assert {m["temporal_basis"] for m in matches} == {"containing interval"}
+
+
+@mark.parametrize(
+    "params",
+    [
+        {},
+        {"col_id": 490, "strat_name": "Mancos"},
+        {"spatial_tolerance": 50},
+    ],
+    ids=["no-age-params", "by-col-id", "spatial-only"],
+)
+def test_temporal_basis_is_null_without_any_age_constraint(client, params):
+    """No interval, no b_age/t_age, no age_tolerance means no temporal filter ran.
+
+    Reporting 'containing interval' there would claim the units had been checked
+    against a time window when none was applied, so the field is null instead.
+    """
+    query = {**LAWRENCE_NO_INTERVAL, "all": True, **params}
+    response = client.get("/strat-names", params=query)
+    assert response.status_code == 200
+    matches = response.json()["results"][0]["unit_matches"]
+    assert len(matches) >= 1
+    assert {m["temporal_basis"] for m in matches} == {None}
+
+
+def test_temporal_basis_is_set_for_a_half_open_age_window(client):
+    """One bound is still a temporal constraint, so the basis is reported."""
+    response = client.get(
+        "/strat-names",
+        params={**LAWRENCE_NO_INTERVAL, "b_age": 307.0, "all": True},
     )
     assert response.status_code == 200
     matches = response.json()["results"][0]["unit_matches"]
@@ -682,6 +723,196 @@ def test_negative_spatial_tolerance_is_rejected(client):
     """A negative distance is meaningless and must be a 422."""
     response = client.get("/strat-names", params={**LAWRENCE, "spatial_tolerance": -1})
     assert response.status_code == 422
+
+
+# -- `all` in the POST body, unknown intervals, unit dedup -------------------
+
+
+def test_batch_all_in_body_is_honored(client):
+    """A body-level "all": 1 widens that item's results; it used to be dropped."""
+    body = [{"identifier": 1, "strat_name": "Lawrence", "all": 1, **LAWRENCE_POSITION}]
+    response = client.post(
+        "/strat-names",
+        params={"interval": "Kasimovian", "age_tolerance": 2},
+        json=body,
+    )
+    assert response.status_code == 200
+    matches = response.json()["results"][0]["unit_matches"]
+    assert len({m["priority"] for m in matches}) > 1
+
+
+def test_batch_all_query_param_sets_the_batch_default(client):
+    """?all= applies to every item that does not set its own."""
+    body = [{"identifier": 1, "strat_name": "Lawrence", **LAWRENCE_POSITION}]
+    shared = {"interval": "Kasimovian", "age_tolerance": 2}
+    widened = client.post("/strat-names", params={**shared, "all": True}, json=body)
+    narrow = client.post("/strat-names", params=shared, json=body)
+    assert widened.status_code == 200 and narrow.status_code == 200
+    wide_matches = widened.json()["results"][0]["unit_matches"]
+    narrow_matches = narrow.json()["results"][0]["unit_matches"]
+    assert len(wide_matches) > len(narrow_matches)
+    assert {m["priority"] for m in narrow_matches} == {0.0}
+
+
+def test_batch_item_all_overrides_the_query_default(client):
+    """An item's own `all` wins over ?all=, in both directions."""
+    response = client.post(
+        "/strat-names",
+        params={"interval": "Kasimovian", "age_tolerance": 2, "all": True},
+        json=[
+            {"identifier": "inherits", "strat_name": "Lawrence", **LAWRENCE_POSITION},
+            {
+                "identifier": "opts-out",
+                "strat_name": "Lawrence",
+                "all": 0,
+                **LAWRENCE_POSITION,
+            },
+        ],
+    )
+    assert response.status_code == 200
+    inherits, opts_out = (r["unit_matches"] for r in response.json()["results"])
+    assert len({m["priority"] for m in inherits}) > 1
+    assert {m["priority"] for m in opts_out} == {0.0}
+
+
+@mark.parametrize(
+    "params",
+    [
+        {"interval": "NotARealInterval"},
+        {"b_interval": "NotARealInterval", "t_interval": "Kasimovian"},
+        {"t_interval": "NotARealInterval", "b_interval": "Kasimovian"},
+    ],
+    ids=["interval", "b_interval", "t_interval"],
+)
+def test_unknown_interval_returns_422(client, params):
+    """An interval Macrostrat does not have is a 422 naming the bad value, not a 500."""
+    response = client.get(
+        "/strat-names", params={**LAWRENCE_POSITION, "strat_name": "Lawrence", **params}
+    )
+    assert response.status_code == 422
+    assert "NotARealInterval" in response.text
+    assert "does not exist in Macrostrat" in response.text
+
+
+def test_matches_are_unique_per_unit_and_column(client):
+    """A unit reached by several names appears once, at its best priority.
+
+    Both 'Lawrence' (1105) and 'Lawrence Shale' (71361) resolve to unit 3891 in
+    col 100, which previously produced two identical rows at the same priority.
+    """
+    response = client.get(
+        "/strat-names", params={**LAWRENCE, "age_tolerance": 2, "all": True}
+    )
+    assert response.status_code == 200
+    matches = response.json()["results"][0]["unit_matches"]
+
+    pairs = [(m["unit_id"], m["col_id"]) for m in matches]
+    assert len(pairs) == len(set(pairs)), f"duplicate (unit_id, col_id) in {pairs}"
+    # The kept row is the best-priority one for that unit.
+    for match in matches:
+        same_unit = [m for m in matches if m["unit_id"] == match["unit_id"]]
+        assert match["priority"] == min(m["priority"] for m in same_unit)
+
+
+# -- string parameters are case-insensitive ----------------------------------
+
+
+@mark.parametrize("interval", ["Kasimovian", "kasimovian", "KASIMOVIAN", "kAsImOvIaN"])
+def test_interval_name_is_case_insensitive(client, interval):
+    """Any casing of an interval name resolves to the same age window."""
+    response = client.get(
+        "/strat-names",
+        params={**LAWRENCE_NO_INTERVAL, "interval": interval, "all": True},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["results"][0]["unit_matches"]
+
+
+def test_interval_casings_give_identical_results(client):
+    """Casing changes nothing about the matches returned."""
+    canonical = client.get(
+        "/strat-names",
+        params={**LAWRENCE_NO_INTERVAL, "interval": "Kasimovian", "all": True},
+    ).json()["results"][0]["unit_matches"]
+    lowered = client.get(
+        "/strat-names",
+        params={**LAWRENCE_NO_INTERVAL, "interval": "kasimovian", "all": True},
+    ).json()["results"][0]["unit_matches"]
+    assert canonical == lowered
+
+
+@mark.parametrize("field", ["b_interval", "t_interval"])
+def test_bounding_interval_names_are_case_insensitive(client, field):
+    """b_interval and t_interval fold case the same way as interval."""
+    other = "t_interval" if field == "b_interval" else "b_interval"
+    response = client.get(
+        "/strat-names",
+        params={
+            **LAWRENCE_NO_INTERVAL,
+            field: "kasimovian",
+            other: "gzhelian",
+            "all": True,
+        },
+    )
+    assert response.status_code == 200, response.text
+
+
+def test_exact_interval_casing_still_wins(client):
+    """'M10n' and 'M10N' are distinct intervals; exact spelling must not be folded away."""
+    setup_intervals_response = client.get(
+        "/strat-names",
+        params={**LAWRENCE_NO_INTERVAL, "interval": "M10n"},
+    )
+    # Either a match or no match is fine — what matters is that it resolves at all.
+    assert setup_intervals_response.status_code == 200, setup_intervals_response.text
+
+
+@mark.parametrize("value", ["rank-up", "RANK-UP", "Rank-Up"])
+def test_name_basis_is_case_insensitive(client, value):
+    """name_basis is a Literal, so it needs folding before validation."""
+    response = client.get(
+        "/strat-names",
+        params={
+            "col_id": 490,
+            "strat_name": "Navajo Sandstone",
+            "all": True,
+            "name_basis": value,
+        },
+    )
+    assert response.status_code == 200, response.text
+    matches = response.json()["results"][0]["unit_matches"]
+    assert all(m["name_basis"] == "rank-up" for m in matches)
+
+
+@mark.parametrize("value", ["strat_name", "STRAT_NAME", "Strat_Name"])
+def test_priority_is_case_insensitive(client, value):
+    """priority is also a Literal and must accept any casing."""
+    response = client.get(
+        "/strat-names",
+        params={"col_id": 490, "strat_name": "Mancos", "priority": value},
+    )
+    assert response.status_code == 200, response.text
+
+
+@mark.parametrize("value", ["Lawrence", "lawrence", "LAWRENCE"])
+def test_strat_name_is_case_insensitive(client, value):
+    """strat_name is folded by clean_strat_name on both the query and the db side."""
+    response = client.get(
+        "/strat-names",
+        params={**LAWRENCE_NO_INTERVAL, "strat_name": value, "all": True},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["results"][0]["unit_matches"]
+
+
+def test_unknown_interval_is_still_rejected_whatever_the_casing(client):
+    """Folding case must not turn a genuinely unknown interval into a match."""
+    response = client.get(
+        "/strat-names",
+        params={**LAWRENCE_NO_INTERVAL, "interval": "notarealinterval"},
+    )
+    assert response.status_code == 422
+    assert "does not exist in Macrostrat" in response.text
 
 
 def test_match_types_all_true(client):

--- a/services/api-v3/api/match/test_match_route.py
+++ b/services/api-v3/api/match/test_match_route.py
@@ -15,9 +15,9 @@ from . import MatchQuery, router, setup_intervals
 
 # TODO: just import the enums from the parent module
 valid_name_bases = {"exact", "concept", "rank-up", "rank-down", "synonym"}
-valid_spatial_bases = {"containing column", "adjacent column"}
+valid_location_bases = {"containing column", "adjacent column"}
 # None is valid: an unconstrained query applies no temporal filter at all.
-valid_temporal_bases = {"containing interval", "adjacent interval", None}
+valid_age_bases = {"containing interval", "adjacent interval", None}
 
 
 def assert_valid_unit_matches(matches):
@@ -30,8 +30,8 @@ def assert_valid_unit_matches(matches):
         assert match["unit_id"] is not None
         assert match["strat_name_id"] is not None
         assert match["name_basis"] in valid_name_bases
-        assert match["spatial_basis"] in valid_spatial_bases
-        assert match["temporal_basis"] in valid_temporal_bases
+        assert match["location_basis"] in valid_location_bases
+        assert match["age_basis"] in valid_age_bases
         assert "concept_name" in match
 
 
@@ -503,8 +503,8 @@ def test_age_tolerance_recovers_the_containing_column(client):
     match = recovered[0]
     assert match["unit_id"] == 3962
     assert match["name_basis"] == "exact"
-    assert match["spatial_basis"] == "containing column"
-    assert match["temporal_basis"] == "adjacent interval"
+    assert match["location_basis"] == "containing column"
+    assert match["age_basis"] == "adjacent interval"
     # Its age range falls outside the Kasimovian, but within the tolerance of it.
     assert match["b_age"] < 303.7
     assert match["b_age"] >= 303.7 - 0.5
@@ -514,7 +514,7 @@ def test_age_tolerance_ranks_the_containing_column_first(client):
     """Michael's real call: the default all=false now returns his own column.
 
     priority is unchanged by this feature — it still keys on name_basis and
-    spatial_basis — and an exact match in the containing column outranks the
+    location_basis — and an exact match in the containing column outranks the
     rank-up adjacent-column matches that a strict query returns.
     """
     response = client.get("/strat-names", params={**LAWRENCE, "age_tolerance": 0.5})
@@ -545,7 +545,7 @@ def test_age_tolerance_smaller_than_the_gap_changes_nothing(client):
     ],
     ids=["interval", "absolute-ages", "b/t-intervals"],
 )
-def test_temporal_basis_is_containing_without_tolerance(client, age_params):
+def test_age_basis_is_containing_without_tolerance(client, age_params):
     """Given an age window but no tolerance, every match overlapped it outright."""
     response = client.get(
         "/strat-names", params={**LAWRENCE_NO_INTERVAL, **age_params, "all": True}
@@ -553,7 +553,7 @@ def test_temporal_basis_is_containing_without_tolerance(client, age_params):
     assert response.status_code == 200
     matches = response.json()["results"][0]["unit_matches"]
     assert len(matches) >= 1
-    assert {m["temporal_basis"] for m in matches} == {"containing interval"}
+    assert {m["age_basis"] for m in matches} == {"containing interval"}
 
 
 @mark.parametrize(
@@ -561,11 +561,11 @@ def test_temporal_basis_is_containing_without_tolerance(client, age_params):
     [
         {},
         {"col_id": 490, "strat_name": "Mancos"},
-        {"spatial_tolerance": 50},
+        {"location_tolerance": 50},
     ],
     ids=["no-age-params", "by-col-id", "spatial-only"],
 )
-def test_temporal_basis_is_null_without_any_age_constraint(client, params):
+def test_age_basis_is_null_without_any_age_constraint(client, params):
     """No interval, no b_age/t_age, no age_tolerance means no temporal filter ran.
 
     Reporting 'containing interval' there would claim the units had been checked
@@ -576,10 +576,10 @@ def test_temporal_basis_is_null_without_any_age_constraint(client, params):
     assert response.status_code == 200
     matches = response.json()["results"][0]["unit_matches"]
     assert len(matches) >= 1
-    assert {m["temporal_basis"] for m in matches} == {None}
+    assert {m["age_basis"] for m in matches} == {None}
 
 
-def test_temporal_basis_is_set_for_a_half_open_age_window(client):
+def test_age_basis_is_set_for_a_half_open_age_window(client):
     """One bound is still a temporal constraint, so the basis is reported."""
     response = client.get(
         "/strat-names",
@@ -588,7 +588,7 @@ def test_temporal_basis_is_set_for_a_half_open_age_window(client):
     assert response.status_code == 200
     matches = response.json()["results"][0]["unit_matches"]
     assert len(matches) >= 1
-    assert {m["temporal_basis"] for m in matches} == {"containing interval"}
+    assert {m["age_basis"] for m in matches} == {"containing interval"}
 
 
 def test_age_tolerance_requires_an_age_window(client):
@@ -617,7 +617,7 @@ def test_age_tolerance_accepts_an_absolute_age_window(client):
     assert 101 in {m["col_id"] for m in matches}
 
 
-# -- spatial_tolerance -------------------------------------------------------
+# -- location_tolerance -------------------------------------------------------
 
 # Column 101 contains the Lawrence collection. Its edge-sharing neighbours are
 # 100, 102, 103, 108 and 109; column 90 lies further out and only comes within
@@ -635,20 +635,20 @@ def cols_returned(client, **params):
     return {m["col_id"] for m in matches if m["col_id"] is not None}
 
 
-def test_default_spatial_tolerance_matches_the_old_degree_buffer(client):
+def test_default_location_tolerance_matches_the_old_degree_buffer(client):
     """The 1.11 km default reproduces the column set the 0.01-degree buffer gave."""
     assert cols_returned(client, age_tolerance=0.5) <= LAWRENCE_NEIGHBOURS
 
 
-def test_spatial_tolerance_changes_the_search(client):
+def test_location_tolerance_changes_the_search(client):
     """A larger tolerance reaches further, and always keeps the containing column."""
-    near = cols_returned(client, age_tolerance=0.5, spatial_tolerance=1.11)
-    far = cols_returned(client, age_tolerance=0.5, spatial_tolerance=100)
+    near = cols_returned(client, age_tolerance=0.5, location_tolerance=1.11)
+    far = cols_returned(client, age_tolerance=0.5, location_tolerance=100)
     assert near != far
     assert 101 in near and 101 in far
 
 
-def test_spatial_tolerance_is_monotonic(client):
+def test_location_tolerance_is_monotonic(client):
     """Widening the tolerance only adds columns, it never swaps them out.
 
     This holds because the DISTINCT ON in column-strat-names.sql keys on col_id and
@@ -656,34 +656,34 @@ def test_spatial_tolerance_is_monotonic(client):
     all adjacent columns, so a distant column could displace a nearer one as the
     candidate set grew.
     """
-    near = cols_returned(client, age_tolerance=0.5, spatial_tolerance=1.11)
-    far = cols_returned(client, age_tolerance=0.5, spatial_tolerance=100)
+    near = cols_returned(client, age_tolerance=0.5, location_tolerance=1.11)
+    far = cols_returned(client, age_tolerance=0.5, location_tolerance=100)
     assert near < far, f"expected {near} to be a strict subset of {far}"
 
 
-def test_spatial_tolerance_zero_still_admits_touching_columns(client):
+def test_location_tolerance_zero_still_admits_touching_columns(client):
     """Columns tessellate, so neighbours are at distance 0 and survive a 0 km tolerance.
 
     ST_DWithin(a, b, 0) is 'touching or overlapping', not 'same column'. Use the
     adjacent-columns match type to restrict to the containing column.
     """
-    assert cols_returned(client, age_tolerance=0.5, spatial_tolerance=0) != {101}
+    assert cols_returned(client, age_tolerance=0.5, location_tolerance=0) != {101}
 
 
-def test_spatial_tolerance_is_not_cached_across_values(client):
+def test_location_tolerance_is_not_cached_across_values(client):
     """Tolerance changes the SQL, so it must be part of the column-units cache key.
 
     Requesting a wide tolerance after a narrow one (and vice versa) must not return
     the earlier result.
     """
-    wide_first = cols_returned(client, age_tolerance=0.5, spatial_tolerance=100)
-    narrow = cols_returned(client, age_tolerance=0.5, spatial_tolerance=1.11)
-    wide_again = cols_returned(client, age_tolerance=0.5, spatial_tolerance=100)
+    wide_first = cols_returned(client, age_tolerance=0.5, location_tolerance=100)
+    narrow = cols_returned(client, age_tolerance=0.5, location_tolerance=1.11)
+    wide_again = cols_returned(client, age_tolerance=0.5, location_tolerance=100)
     assert wide_first == wide_again
     assert narrow != wide_first
 
 
-def test_spatial_tolerance_is_bound_in_kilometres_as_supplied(db):
+def test_location_tolerance_is_bound_in_kilometres_as_supplied(db):
     """The SQL receives the caller's value verbatim; the km->m conversion is in SQL.
 
     A tolerance of 1000 km must reach far more columns than 1000 m would, which is
@@ -695,15 +695,15 @@ def test_spatial_tolerance_is_bound_in_kilometres_as_supplied(db):
         db.run_query("SELECT lith name FROM macrostrat.liths").scalars().all()
     )
     with db.engine.connect() as conn:
-        near = get_column_units(conn, 101, spatial_tolerance=1)
-        far = get_column_units(conn, 101, spatial_tolerance=1000)
+        near = get_column_units(conn, 101, location_tolerance=1)
+        far = get_column_units(conn, 101, location_tolerance=1000)
     assert far.col_id.nunique() > near.col_id.nunique()
 
 
-def test_spatial_tolerance_default_is_used_when_absent(db):
-    """Omitting the parameter falls back to DEFAULT_SPATIAL_TOLERANCE_KM."""
+def test_location_tolerance_default_is_used_when_absent(db):
+    """Omitting the parameter falls back to DEFAULT_LOCATION_TOLERANCE_KM."""
     from macrostrat.match_utils import (
-        DEFAULT_SPATIAL_TOLERANCE_KM,
+        DEFAULT_LOCATION_TOLERANCE_KM,
         create_ignore_list,
         get_column_units,
     )
@@ -714,14 +714,14 @@ def test_spatial_tolerance_default_is_used_when_absent(db):
     with db.engine.connect() as conn:
         implicit = get_column_units(conn, 101)
         explicit = get_column_units(
-            conn, 101, spatial_tolerance=DEFAULT_SPATIAL_TOLERANCE_KM
+            conn, 101, location_tolerance=DEFAULT_LOCATION_TOLERANCE_KM
         )
     assert set(implicit.col_id.dropna()) == set(explicit.col_id.dropna())
 
 
-def test_negative_spatial_tolerance_is_rejected(client):
+def test_negative_location_tolerance_is_rejected(client):
     """A negative distance is meaningless and must be a 422."""
-    response = client.get("/strat-names", params={**LAWRENCE, "spatial_tolerance": -1})
+    response = client.get("/strat-names", params={**LAWRENCE, "location_tolerance": -1})
     assert response.status_code == 422
 
 
@@ -1181,7 +1181,7 @@ def test_name_basis_values_are_valid(client):
     for result in data["results"]:
         for match in result["unit_matches"]:
             assert match["name_basis"] in valid_name_bases
-            assert match["spatial_basis"] in valid_spatial_bases
+            assert match["location_basis"] in valid_location_bases
 
 
 def test_match_result_has_concept_name(client):

--- a/services/api-v3/api/match/test_match_route.py
+++ b/services/api-v3/api/match/test_match_route.py
@@ -16,6 +16,7 @@ from . import MatchQuery, router, setup_intervals
 # TODO: just import the enums from the parent module
 valid_name_bases = {"exact", "concept", "rank-up", "rank-down", "synonym"}
 valid_spatial_bases = {"containing column", "adjacent column"}
+valid_temporal_bases = {"containing interval", "adjacent interval"}
 
 
 def assert_valid_unit_matches(matches):
@@ -29,6 +30,7 @@ def assert_valid_unit_matches(matches):
         assert match["strat_name_id"] is not None
         assert match["name_basis"] in valid_name_bases
         assert match["spatial_basis"] in valid_spatial_bases
+        assert match["temporal_basis"] in valid_temporal_bases
         assert "concept_name" in match
 
 
@@ -459,6 +461,119 @@ def test_invalid_age_constraints(client):
     assert len(results) == 1
     messages = results[0]["messages"]
     assert any("Inconsistent age constraints" in msg["message"] for msg in messages)
+
+
+# -- age_tolerance: PBDB collection 122495 -----------------------------------
+
+# Fossils were collected from the Lawrence Fm, which
+# sits in column 101. The Kasimovian tops out at 303.7 Ma while the Lawrence Fm
+# in that column runs 303.4818–303.2636 Ma, so a strict overlap test misses the
+# collection's own column by 0.2182 Myr and returns only adjacent-column matches.
+LAWRENCE = {
+    "lat": 38.939899,
+    "lng": -95.332901,
+    "strat_name": "Lawrence",
+    "interval": "Kasimovian",
+}
+LAWRENCE_NO_INTERVAL = {k: v for k, v in LAWRENCE.items() if k != "interval"}
+
+
+def test_strict_age_bounds_miss_the_containing_column(client):
+    """Reproduce the bug: without a tolerance, column 101 is filtered out."""
+    response = client.get("/strat-names", params={**LAWRENCE, "all": True})
+    assert response.status_code == 200
+    matches = response.json()["results"][0]["unit_matches"]
+    assert_valid_unit_matches(matches)
+    assert 101 not in {m["col_id"] for m in matches}
+
+
+def test_age_tolerance_recovers_the_containing_column(client):
+    """A 0.5 Myr tolerance surfaces unit 3962 in column 101, tagged as adjacent."""
+    response = client.get(
+        "/strat-names", params={**LAWRENCE, "age_tolerance": 0.5, "all": True}
+    )
+    assert response.status_code == 200
+    matches = response.json()["results"][0]["unit_matches"]
+    assert_valid_unit_matches(matches)
+
+    recovered = [m for m in matches if m["col_id"] == 101]
+    assert len(recovered) == 1
+    match = recovered[0]
+    assert match["unit_id"] == 3962
+    assert match["name_basis"] == "exact"
+    assert match["spatial_basis"] == "containing column"
+    assert match["temporal_basis"] == "adjacent interval"
+    # Its age range falls outside the Kasimovian, but within the tolerance of it.
+    assert match["b_age"] < 303.7
+    assert match["b_age"] >= 303.7 - 0.5
+
+
+def test_age_tolerance_ranks_the_containing_column_first(client):
+    """Michael's real call: the default all=false now returns his own column.
+
+    priority is unchanged by this feature — it still keys on name_basis and
+    spatial_basis — and an exact match in the containing column outranks the
+    rank-up adjacent-column matches that a strict query returns.
+    """
+    response = client.get("/strat-names", params={**LAWRENCE, "age_tolerance": 0.5})
+    assert response.status_code == 200
+    matches = response.json()["results"][0]["unit_matches"]
+    assert len(matches) == 1
+    assert matches[0]["unit_id"] == 3962
+    assert matches[0]["col_id"] == 101
+    assert matches[0]["priority"] == 0.0
+
+
+def test_age_tolerance_smaller_than_the_gap_changes_nothing(client):
+    """The gap is 0.2182 Myr, so a 0.1 Myr tolerance must not recover column 101."""
+    response = client.get(
+        "/strat-names", params={**LAWRENCE, "age_tolerance": 0.1, "all": True}
+    )
+    assert response.status_code == 200
+    matches = response.json()["results"][0]["unit_matches"]
+    assert 101 not in {m["col_id"] for m in matches}
+
+
+@mark.parametrize(
+    "age_params",
+    [{}, {"interval": "Kasimovian"}, {"b_age": 307.0, "t_age": 303.7}],
+    ids=["unconstrained", "interval", "absolute-ages"],
+)
+def test_temporal_basis_is_containing_without_tolerance(client, age_params):
+    """With no age_tolerance every match overlapped the window outright."""
+    response = client.get(
+        "/strat-names", params={**LAWRENCE_NO_INTERVAL, **age_params, "all": True}
+    )
+    assert response.status_code == 200
+    matches = response.json()["results"][0]["unit_matches"]
+    assert len(matches) >= 1
+    assert {m["temporal_basis"] for m in matches} == {"containing interval"}
+
+
+def test_age_tolerance_requires_an_age_window(client):
+    """A tolerance with no window to widen is a 422, not a silent no-op."""
+    response = client.get(
+        "/strat-names", params={**LAWRENCE_NO_INTERVAL, "age_tolerance": 0.5}
+    )
+    assert response.status_code == 422
+    assert "age_tolerance" in response.text
+
+
+def test_age_tolerance_accepts_an_absolute_age_window(client):
+    """An explicit b_age/t_age pair is a valid window for the tolerance."""
+    response = client.get(
+        "/strat-names",
+        params={
+            **LAWRENCE_NO_INTERVAL,
+            "b_age": 307.0,
+            "t_age": 303.7,
+            "age_tolerance": 0.5,
+            "all": True,
+        },
+    )
+    assert response.status_code == 200
+    matches = response.json()["results"][0]["unit_matches"]
+    assert 101 in {m["col_id"] for m in matches}
 
 
 def test_match_types_all_true(client):

--- a/services/api-v3/api/match/test_match_route.py
+++ b/services/api-v3/api/match/test_match_route.py
@@ -576,6 +576,114 @@ def test_age_tolerance_accepts_an_absolute_age_window(client):
     assert 101 in {m["col_id"] for m in matches}
 
 
+# -- spatial_tolerance -------------------------------------------------------
+
+# Column 101 contains the Lawrence collection. Its edge-sharing neighbours are
+# 100, 102, 103, 108 and 109; column 90 lies further out and only comes within
+# reach at a wider tolerance.
+LAWRENCE_NEIGHBOURS = {100, 101, 102, 103, 108, 109}
+
+
+def cols_returned(client, **params):
+    response = client.get(
+        "/strat-names",
+        params={**LAWRENCE, "all": True, **params},
+    )
+    assert response.status_code == 200
+    matches = response.json()["results"][0]["unit_matches"]
+    return {m["col_id"] for m in matches if m["col_id"] is not None}
+
+
+def test_default_spatial_tolerance_matches_the_old_degree_buffer(client):
+    """The 1.11 km default reproduces the column set the 0.01-degree buffer gave."""
+    assert cols_returned(client, age_tolerance=0.5) <= LAWRENCE_NEIGHBOURS
+
+
+def test_spatial_tolerance_changes_the_search(client):
+    """A larger tolerance reaches further, and always keeps the containing column."""
+    near = cols_returned(client, age_tolerance=0.5, spatial_tolerance=1.11)
+    far = cols_returned(client, age_tolerance=0.5, spatial_tolerance=100)
+    assert near != far
+    assert 101 in near and 101 in far
+
+
+def test_spatial_tolerance_is_monotonic(client):
+    """Widening the tolerance only adds columns, it never swaps them out.
+
+    This holds because the DISTINCT ON in column-strat-names.sql keys on col_id and
+    unit_id. Keying on strat_name_id alone kept one arbitrary row per name across
+    all adjacent columns, so a distant column could displace a nearer one as the
+    candidate set grew.
+    """
+    near = cols_returned(client, age_tolerance=0.5, spatial_tolerance=1.11)
+    far = cols_returned(client, age_tolerance=0.5, spatial_tolerance=100)
+    assert near < far, f"expected {near} to be a strict subset of {far}"
+
+
+def test_spatial_tolerance_zero_still_admits_touching_columns(client):
+    """Columns tessellate, so neighbours are at distance 0 and survive a 0 km tolerance.
+
+    ST_DWithin(a, b, 0) is 'touching or overlapping', not 'same column'. Use the
+    adjacent-columns match type to restrict to the containing column.
+    """
+    assert cols_returned(client, age_tolerance=0.5, spatial_tolerance=0) != {101}
+
+
+def test_spatial_tolerance_is_not_cached_across_values(client):
+    """Tolerance changes the SQL, so it must be part of the column-units cache key.
+
+    Requesting a wide tolerance after a narrow one (and vice versa) must not return
+    the earlier result.
+    """
+    wide_first = cols_returned(client, age_tolerance=0.5, spatial_tolerance=100)
+    narrow = cols_returned(client, age_tolerance=0.5, spatial_tolerance=1.11)
+    wide_again = cols_returned(client, age_tolerance=0.5, spatial_tolerance=100)
+    assert wide_first == wide_again
+    assert narrow != wide_first
+
+
+def test_spatial_tolerance_is_bound_in_kilometres_as_supplied(db):
+    """The SQL receives the caller's value verbatim; the km->m conversion is in SQL.
+
+    A tolerance of 1000 km must reach far more columns than 1000 m would, which is
+    what a stray Python-side conversion would silently produce.
+    """
+    from macrostrat.match_utils import create_ignore_list, get_column_units
+
+    create_ignore_list(
+        db.run_query("SELECT lith name FROM macrostrat.liths").scalars().all()
+    )
+    with db.engine.connect() as conn:
+        near = get_column_units(conn, 101, spatial_tolerance=1)
+        far = get_column_units(conn, 101, spatial_tolerance=1000)
+    assert far.col_id.nunique() > near.col_id.nunique()
+
+
+def test_spatial_tolerance_default_is_used_when_absent(db):
+    """Omitting the parameter falls back to DEFAULT_SPATIAL_TOLERANCE_KM."""
+    from macrostrat.match_utils import (
+        DEFAULT_SPATIAL_TOLERANCE_KM,
+        create_ignore_list,
+        get_column_units,
+    )
+
+    create_ignore_list(
+        db.run_query("SELECT lith name FROM macrostrat.liths").scalars().all()
+    )
+    with db.engine.connect() as conn:
+        implicit = get_column_units(conn, 101)
+        explicit = get_column_units(
+            conn, 101, spatial_tolerance=DEFAULT_SPATIAL_TOLERANCE_KM
+        )
+    assert set(implicit.col_id.dropna()) == set(explicit.col_id.dropna())
+
+
+def test_negative_spatial_tolerance_is_rejected(client):
+    """A negative distance is meaningless and must be a 422."""
+    response = client.get("/strat-names", params={**LAWRENCE, "spatial_tolerance": -1})
+    assert response.status_code == 422
+
+
 def test_match_types_all_true(client):
     """With all=true, return all API-supported Mancos matches ordered by priority."""
     response = client.get(


### PR DESCRIPTION
# Match API: age and location tolerances

## Summary

Adds configurable age and location tolerances to stratigraphic-name matching and fixes several issues discovered while testing them.

The main motivation was a PBDB collection whose correct containing-column match was excluded because its age range missed the interval boundary by only 0.2182 Myr. Using `age_tolerance=0.5` now recovers that match.

## Changes

* Added `age_tolerance`, measured in millions of years.

  * Default: `0`
  * Expands the requested age window in both directions.
  * Requires an interval or explicit t_age/b_age bounds.

* Added `age_basis` to match responses:

  * `containing interval`
  * `adjacent interval`
  * `null` when no age constraint was supplied

* Added `location_tolerance`, measured in kilometers.

  * Default: `1.11`
  * Replaces the previous `0.01°` buffer with metric `ST_DWithin` matching.
  * Produces consistent distances regardless of latitude.

## Fixes

* Fixed `DISTINCT ON` dropping valid matches from adjacent columns.
* Fixed `all` being ignored inside POST batch items.
* Unknown interval names now return `422` instead of `500`.
* Interval names and other string parameters are now case-insensitive while preserving exact-case matches.
* Duplicate matches for the same `(unit_id, col_id)` are collapsed to the best-priority result.
* Batch validation errors now correctly return `422`.

## Notable changes

* Response field `spatial_basis` was renamed to `location_basis`.
* POST items that already include `all` will now have that value honored.
* Responses may contain:
  * Fewer duplicate rows for the same unit and column.
  * More rows when one name resolves to units in multiple columns.

## Testing

Tested against a clone of production:

* Match API: **80 passing**
* Match utilities: **21 passing**

Coverage includes age and location tolerances, batch inheritance, case-insensitive parameters, invalid intervals, monotonic location searches, and duplicate removal.

## Follow-ups

Not included in this PR:

* Support footprint-only matches outside Macrostrat column areas.
* Need to determine how to implement bbox matches.

